### PR TITLE
Miscellaneous improvements

### DIFF
--- a/lib/ex_png/chunks/image_data.ex
+++ b/lib/ex_png/chunks/image_data.ex
@@ -34,7 +34,7 @@ defmodule ExPng.Chunks.ImageData do
     data =
       Enum.map(pixels, fn line ->
         Enum.reduce(line, <<0>>, fn pixel, acc ->
-          acc <> <<pixel.r, pixel.g, pixel.b>>
+          acc <> <<pixel.r, pixel.g, pixel.b, pixel.a>>
         end)
       end)
       |> Enum.reverse()
@@ -61,9 +61,12 @@ defmodule ExPng.Chunks.ImageData do
   defp deflate(data) do
     zstream = :zlib.open()
     :zlib.deflateInit(zstream)
-    [deflated_data] = :zlib.deflate(zstream, data, :finish)
+    deflated_data = :zlib.deflate(zstream, data, :finish)
     :zlib.deflateEnd(zstream)
     :zlib.close(zstream)
     deflated_data
+    |> List.flatten()
+    |> Enum.reverse()
+    |> Enum.reduce(&Kernel.<>/2)
   end
 end

--- a/lib/ex_png/image.ex
+++ b/lib/ex_png/image.ex
@@ -85,8 +85,8 @@ defmodule ExPng.Image do
       true ->
         pixel =
           image.pixels
-          |> Enum.at(round(y))
-          |> Enum.at(round(x))
+          |> Enum.at(y)
+          |> Enum.at(x)
 
         {:ok, pixel}
 

--- a/lib/ex_png/image/drawing.ex
+++ b/lib/ex_png/image/drawing.ex
@@ -80,7 +80,7 @@ defmodule ExPng.Image.Drawing do
 
   def put_color(image, x, y, color, steep, c) do
     [x, y] = if steep, do: [y, x], else: [x, y]
-    draw(image, [x, y], anti_alias(color, at(image, [x, y]), c))
+    draw(image, [round(x), round(y)], anti_alias(color, at(image, [round(x), round(y)]), c))
   end
 
   def anti_alias(color, old, ratio) do

--- a/lib/ex_png/image/encoding.ex
+++ b/lib/ex_png/image/encoding.ex
@@ -24,14 +24,11 @@ defmodule ExPng.Image.Encoding do
     %Header{
       width: image.width,
       height: image.height,
-      bit_depth: calculate_bit_depth(image),
-      color_type: calculate_color_type(image),
+      bit_depth: 8,
+      color_type: @truecolor_alpha,
       compression: 0,
       filter: 0,
       interlace: 0
     }
   end
-
-  def calculate_bit_depth(_image), do: 8
-  def calculate_color_type(_image), do: @truecolor
 end

--- a/lib/ex_png/image/line.ex
+++ b/lib/ex_png/image/line.ex
@@ -13,7 +13,7 @@ defmodule ExPng.Image.Line do
 
   def to_pixels(line, bit_depth, color_type, palette \\ nil)
 
-  def to_pixels(%__MODULE__{data: data}, 1, 0, _) do
+  def to_pixels(%__MODULE__{data: data}, 1, @grayscale, _) do
     for <<x::1 <- data>>, do: Pixel.grayscale(x * 255)
   end
 
@@ -182,7 +182,9 @@ defmodule ExPng.Image.Line do
 
   defp calculate_paeth_delta(a, b, c) do
     p = a + b - c
-    [pa, pb, pc] = Enum.map([a, b, c], &abs(p - &1))
+    pa = abs(p - a)
+    pb = abs(p - b)
+    pc = abs(p - c)
 
     cond do
       pa <= pb && pa <= pc -> a


### PR DESCRIPTION
* Default encoding uses `@truecolor_alpha` so that transparency is preserved
* Fix a big in the `deflate` function that arises when decoding large enough files
* Move coordinate rounding out of the Access implementation into the Xiaolin Wu line algorithm to avoid unneeded calls
* Remove `Enum.map(&abs/1)` call in the Paeth algorithm to improve runtime (~15-20% improvement)