### PR TITLE
Fix bug with order of operations for merging/inflating image data chunks

### DIFF
--- a/lib/ex_png/chunks/image_data.ex
+++ b/lib/ex_png/chunks/image_data.ex
@@ -6,10 +6,6 @@ defmodule ExPng.Chunks.ImageData do
   def new("IDAT", data) do
     image_data =
       data
-      |> inflate()
-      |> List.flatten()
-      |> reduce_to_binary()
-
     {:ok, %__MODULE__{data: image_data}}
   end
 
@@ -25,6 +21,9 @@ defmodule ExPng.Chunks.ImageData do
     data =
       data_chunks
       |> Enum.map(& &1.data)
+      |> reduce_to_binary()
+      |> inflate()
+      |> List.flatten()
       |> reduce_to_binary()
 
     %ExPng.Chunks.ImageData{data: data}
@@ -49,7 +48,7 @@ defmodule ExPng.Chunks.ImageData do
     end)
   end
 
-  defp inflate(data) do
+  def inflate(data) do
     zstream = :zlib.open()
     :zlib.inflateInit(zstream)
     inflated_data = :zlib.inflate(zstream, data)

--- a/lib/ex_png/image/adam7.ex
+++ b/lib/ex_png/image/adam7.ex
@@ -21,7 +21,7 @@ defmodule ExPng.Image.Adam7 do
   end
 
   def extract_sub_images(%RawData{} = raw_data) do
-    [data] = raw_data.data_chunks
+    data = raw_data.data_chunk
     palette = raw_data.palette_chunk
     %{
       width: width,

--- a/lib/ex_png/image/encoding.ex
+++ b/lib/ex_png/image/encoding.ex
@@ -14,7 +14,7 @@ defmodule ExPng.Image.Encoding do
       :ok,
       %RawData{
         header_chunk: header,
-        data_chunks: [image_data_chunk],
+        data_chunk: image_data_chunk,
         end_chunk: %End{}
       }
     }

--- a/lib/ex_png/raw_data.ex
+++ b/lib/ex_png/raw_data.ex
@@ -8,7 +8,7 @@ defmodule ExPng.RawData do
 
   defstruct [
     :header_chunk,
-    :data_chunks,
+    :data_chunk,
     :palette_chunk,
     :ancillary_chunks,
     :end_chunk,
@@ -32,10 +32,7 @@ defmodule ExPng.RawData do
   end
 
   def to_png(%__MODULE__{} = raw_data, filename) do
-    image_data =
-      Enum.reduce(raw_data.data_chunks, <<>>, fn chunk, acc ->
-        acc <> ImageData.to_bytes(chunk)
-      end)
+    image_data = ImageData.to_bytes(raw_data.data_chunk)
 
     data =
       @signature <>
@@ -89,7 +86,7 @@ defmodule ExPng.RawData do
         :ok,
         %__MODULE__{
           header_chunk: header_chunk,
-          data_chunks: data_chunks,
+          data_chunk: ImageData.merge(data_chunks),
           end_chunk: end_chunk,
           palette_chunk: palette,
           ancillary_chunks: chunks


### PR DESCRIPTION
Originally the code was inflating each ImageData chunk before merging them, but merging needs to happen first.

Moved merging into the creation of the `RawData` struct and only persist the merged single data chunk.