### PR TITLE
Refactoring

### DIFF
--- a/bench/flatten_bench.exs
+++ b/bench/flatten_bench.exs
@@ -1,0 +1,13 @@
+defmodule FlattenBench do
+  use Benchfella
+
+  @list 1..10_000
+
+  bench "reduce range" do
+    Enum.reduce(1..100_000, 0, &Kernel.+(&1 * 2, &2))
+  end
+
+  bench "reduce list" do
+    Enum.reduce(Enum.to_list(1..100_000), 0, &Kernel.+(&1 * 2, &2))
+  end
+end

--- a/lib/ex_png/chunks/image_data.ex
+++ b/lib/ex_png/chunks/image_data.ex
@@ -36,7 +36,6 @@ defmodule ExPng.Chunks.ImageData do
       |> Enum.map(& &1.data)
       |> reduce_to_binary()
       |> inflate()
-      |> List.flatten()
       |> reduce_to_binary()
 
     %ExPng.Chunks.ImageData{data: data}
@@ -131,7 +130,6 @@ defmodule ExPng.Chunks.ImageData do
     :zlib.deflateEnd(zstream)
     :zlib.close(zstream)
     deflated_data
-    |> List.flatten()
     |> reduce_to_binary()
   end
 end

--- a/lib/ex_png/image.ex
+++ b/lib/ex_png/image.ex
@@ -80,7 +80,6 @@ defmodule ExPng.Image do
   @spec unique_pixels(__MODULE__.t) :: integer()
   def unique_pixels(%__MODULE__{pixels: pixels}) do
     pixels
-    # |> List.flatten()
     |> Enum.reduce([], fn l, acc -> acc ++ l end)
     |> Enum.uniq()
   end

--- a/lib/ex_png/image.ex
+++ b/lib/ex_png/image.ex
@@ -80,7 +80,8 @@ defmodule ExPng.Image do
   @spec unique_pixels(__MODULE__.t) :: integer()
   def unique_pixels(%__MODULE__{pixels: pixels}) do
     pixels
-    |> List.flatten()
+    # |> List.flatten()
+    |> Enum.reduce([], fn l, acc -> acc ++ l end)
     |> Enum.uniq()
   end
 

--- a/lib/ex_png/image/decoding.ex
+++ b/lib/ex_png/image/decoding.ex
@@ -8,7 +8,7 @@ defmodule ExPng.Image.Decoding do
 
   alias ExPng.{Color, Image, Image.Adam7, Image.Line, RawData}
 
-  def from_raw_data(%ExPng.RawData{header_chunk: %{interlace: 1}} = data) do
+  def from_raw_data(%RawData{header_chunk: %{interlace: 1}} = data) do
     %{width: width, height: height} = data.header_chunk
 
 
@@ -20,38 +20,38 @@ defmodule ExPng.Image.Decoding do
 
     %{image | raw_data: data}
   end
-  def from_raw_data(%ExPng.RawData{} = data) do
-    image =
+  def from_raw_data(%RawData{} = data) do
+    lines =
       data
       |> build_lines()
-      |> filter_pass()
+      |> filter_pass(Color.pixel_bytesize(data))
 
     pixels =
-      image.lines
+      lines
       |> Enum.map(fn line ->
         Line.to_pixels(
           line,
-          image.header_chunk.bit_depth,
-          image.header_chunk.color_mode,
-          image.palette_chunk
+          data.header_chunk.bit_depth,
+          data.header_chunk.color_mode,
+          data.palette_chunk
         ) |> Enum.take(data.header_chunk.width)
       end)
 
     %Image{
       pixels: pixels,
-      raw_data: image,
+      raw_data: data,
       height: length(pixels),
       width: length(Enum.at(pixels, 0))
     }
   end
 
-  def build_lines(%ExPng.RawData{data_chunk: data} = image) do
+  defp build_lines(%RawData{data_chunk: data} = image) do
     with line_size <- Color.line_bytesize(image) do
       lines =
         for <<f, line::bytes-size(line_size) <- data.data>> do
           Line.new(f, line)
         end
-      %{image | lines: lines}
+      lines
     end
   end
 
@@ -62,17 +62,5 @@ defmodule ExPng.Image.Decoding do
     end)
     |> Enum.reverse()
     |> Enum.drop(1)
-  end
-
-  def filter_pass(%RawData{lines: lines} = image) do
-    lines =
-      Enum.reduce(lines, [nil], fn line, [prev | _] = acc ->
-        new_line = Line.filter_pass(line, Color.pixel_bytesize(image), prev)
-        [new_line | acc]
-      end)
-      |> Enum.reverse()
-      |> Enum.drop(1)
-
-    %{image | lines: lines}
   end
 end

--- a/lib/ex_png/image/line.ex
+++ b/lib/ex_png/image/line.ex
@@ -236,9 +236,9 @@ defmodule ExPng.Image.Line do
     prev_line = for <<pixel::bytes-size(pixel_size) <- prev_data>>, do: pixel
 
     x =
-      Enum.reduce(Enum.with_index(data), [pad], fn {byte, i}, [a_byte | _] = acc ->
-        b_byte = Enum.at(prev_line, i)
-        c_byte = if i == 0, do: pad, else: Enum.at(prev_line, i - 1)
+      Enum.chunk_every([pad|prev_line], 2, 1, :discard)
+      |> Enum.zip(data)
+      |> Enum.reduce([pad], fn {[c_byte, b_byte], byte}, [a_byte | _] = acc ->
 
         filtered_byte =
           Enum.reduce(0..(pixel_size - 1), <<>>, fn j, acc ->

--- a/lib/ex_png/image/line.ex
+++ b/lib/ex_png/image/line.ex
@@ -33,6 +33,8 @@ defmodule ExPng.Image.Line do
   use Bitwise
   use ExPng.Constants
 
+  import ExPng.Utilities, only: [reduce_to_binary: 1]
+
   alias ExPng.Pixel
 
 
@@ -214,9 +216,7 @@ defmodule ExPng.Image.Line do
       end)
       |> Enum.reverse()
       |> Enum.drop(1)
-      |> Enum.reduce(<<>>, fn c, acc ->
-        acc <> c
-      end)
+      |> reduce_to_binary()
 
     %{line | data: x}
   end
@@ -254,7 +254,7 @@ defmodule ExPng.Image.Line do
       end)
       |> Enum.reverse()
       |> Enum.drop(1)
-      |> Enum.reduce(<<>>, fn c, acc -> acc <> c end)
+      |> reduce_to_binary()
 
     %{line | data: x}
   end

--- a/lib/ex_png/raw_data.ex
+++ b/lib/ex_png/raw_data.ex
@@ -20,7 +20,6 @@ defmodule ExPng.RawData do
     palette_chunk: Palette.t,
     ancillary_chunks: [Ancillary.t],
     end_chunk: End.t,
-    lines: [ExPng.Image.Line.t, ...]
   }
   defstruct [
     :header_chunk,
@@ -28,7 +27,6 @@ defmodule ExPng.RawData do
     :palette_chunk,
     :ancillary_chunks,
     :end_chunk,
-    :lines
   ]
 
   @doc false

--- a/lib/ex_png/utilities.ex
+++ b/lib/ex_png/utilities.ex
@@ -7,9 +7,10 @@ defmodule ExPng.Utilities do
   Accepts a list of binaries and reduces them to a single
   binary
   """
-  @spec reduce_to_binary([binary]) :: binary
+  @spec reduce_to_binary([binary | [binary]]) :: binary
   def reduce_to_binary(list) do
     list
+    |> List.flatten()
     |> Enum.reverse()
     |> Enum.reduce(&Kernel.<>/2)
   end

--- a/prof/readwrite10.prof
+++ b/prof/readwrite10.prof
@@ -1,0 +1,270 @@
+Compiling 2 files (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2250200    4343.093    5000.399
+:proc_lib.init_p/5                                                 250   39466.493       6.047
+:suspend                                                          2010   38809.187       0.000
+:fprof.apply_start_stop/4                                            0    4343.093       0.008
+anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1    4343.081       0.004
+Enum.reduce/3                                                    62997    3563.193      69.795
+Enum."-reduce/3-lists^foldl/2-0-"/3                             126247    3562.329     554.041
+ExPng.Image.from_file/1                                              1    3249.403       0.005
+ExPng.Image.Decoding.from_raw_data/1                                 1    3247.255       0.007
+ExPng.Image.Decoding.filter_pass/2                                   1    2868.780       0.003
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2868.217       0.538
+ExPng.Image.Line.filter_pass/3                                     494    2867.679       2.922
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1218.932     191.298
+ExPng.Image.to_file/2                                                1    1093.674       0.001
+ExPng.Image.to_file/3                                                1    1093.673       0.006
+ExPng.Image.Encoding.to_raw_data/1                                   1    1086.749       0.004
+Enum.reduce_range_inc/4                                         187482     917.910     336.809
+Enum.map/2                                                           4     848.179       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     848.174       3.350
+ExPng.Chunks.ImageData.from_pixels/2                                 1     720.860       0.010
+:proc_lib.init_p_do_apply/3                                        250     719.818       1.765
+Task.Supervised.reply/4                                            250     718.053       2.753
+Task.Supervised.reply/5                                            250     704.202       2.627
+Enumerable.reduce/3                                                485     648.610       1.061
+Enum.chunk_every/4                                                 241     645.681       0.249
+Stream.Reducers.chunk_every/5                                      241     645.432       0.498
+Enum."-fun.chunk_while/4-"/4                                       241     644.691       0.246
+Enum.chunk_while/4                                                 241     644.445       0.775
+Enumerable.List.reduce/3                                         60732     641.281     128.946
+Task.Supervised.invoke_mfa/2                                       250     605.605       1.521
+:erlang.apply/2                                                    250     604.084       0.919
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     603.165       0.915
+ExPng.Chunks.ImageData.line_to_binary/3                            250     602.250       1.058
+ExPng.Image.unique_pixels/1                                          2     585.959       0.007
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     573.167     384.980
+anonymous fn/3 in Enum.chunk_while/4                             60491     512.148     128.057
+Enum.uniq/1                                                          2     492.722       0.003
+Enum.uniq_by/2                                                       2     492.719       0.003
+Enum.uniq_list/3                                                125002     492.716     359.504
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     463.739       0.367
+Task.async/1                                                       250     463.372       0.326
+Task.async/3                                                       250     463.046       2.110
+Task.Supervised.start_link/4                                       250     457.862       0.637
+:proc_lib.spawn_link/3                                             250     457.225       1.431
+:erlang.spawn_link/3                                               250     394.985     394.985
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     383.286     192.507
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     376.338       0.500
+ExPng.Image.Encoding.build_header/1                                  1     365.885       0.002
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     365.883       0.006
+ExPng.Utilities.reduce_to_binary/1                                 248     335.257       0.817
+Enum.take/2                                                      60744     260.539      67.310
+ExPng.Image.Line.to_pixels/4                                       250     250.718       0.250
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     250.468     187.800
+Enum.reduce/2                                                      498     210.136       0.539
+Enum."-reduce/2-lists^foldl/2-0-"/3                              63506     209.597     137.076
+Enum.take_list/2                                                123501     187.020     186.618
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     182.975     182.574
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500     180.544     180.544
+ExPng.Image.Line."-filter_pass/3-lc$^9/1-3-"/2                   60491     130.344     128.014
+List.flatten/1                                                     248     130.295       0.288
+:lists.flatten/1                                                   248     130.006       0.284
+:lists.do_flatten/2                                              61562     129.722     129.397
+anonymous fn/1 in Enum.uniq/1                                   125000     129.025     128.137
+Enum.zip/2                                                         241     127.761       0.274
+Enum.zip_list/2                                                  60491     127.487     126.953
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-4-"/2                  60491     125.748     125.160
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     109.541       3.003
+Enum.at/2                                                          751      98.937       0.751
+Enum.at/3                                                          751      98.186       1.505
+Enum.slice_any/3                                                   751      96.679       1.503
+:erlang.send/2                                                     500      96.391      96.391
+Enum.drop_list/2                                                 94616      94.872      94.840
+anonymous fn/2 in ExPng.Image.unique_pixels/1                      500      91.931       2.134
+:garbage_collect                                                  4538      71.618      71.618
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1             61026      69.907      67.706
+Range.new/2                                                      62494      64.113      63.350
+:lists.reverse/1                                                 60737      63.155      62.138
+ExPng.Pixel.rgb/3                                                62500      62.618      62.559
+:proc_lib.get_my_name/0                                            250      60.461       0.712
+:proc_lib.proc_info/2                                              250      59.749       1.144
+:erlang.++/2                                                       500      32.389      31.848
+Enum.all?/2                                                          3      22.165       0.003
+Enum.all_list/2                                                   7384      22.162      14.771
+ExPng.Image.Encoding.opaque?/1                                       1      22.158       0.001
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      21.578       4.878
+ExPng.Image.Line.build_pad_for_filter/1                            244      10.892       0.821
+Task.Supervised.initial_call/1                                     250       8.088       1.877
+ExPng.Pixel.opaque?/1                                             7381       7.385       7.383
+ExPng.RawData.to_file/3                                              1       6.918       0.015
+ExPng.Chunks.ImageData.to_bytes/2                                    1       6.245       0.013
+:zlib.dequeue_all_chunks/2                                           2       6.215       0.004
+:zlib.dequeue_all_chunks_1/3                                        39       6.211       0.254
+ExPng.Chunks.ImageData.deflate/2                                     1       6.101       0.039
+:zlib.dequeue_next_chunk/2                                          39       5.544       0.079
+:zlib.deflate/3                                                      1       5.316       0.009
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       4.907       4.772
+Enumerable.Function.reduce/3                                       244       4.766       0.277
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       4.732       0.612
+:zlib."-fun.deflate_nif/4-"/4                                       27       4.672       0.049
+:zlib.deflate_nif/4                                                 27       4.623       4.623
+anonymous fn/4 in Stream.unfold/2                                  244       4.489       0.279
+Process.put/2                                                      500       4.337       2.965
+Stream.do_unfold/4                                                 976       4.210       2.703
+Task.await/1                                                       250       4.120       0.612
+Task.Supervised.get_initial_call/1                                 250       3.986       2.570
+Task.await/2                                                       250       3.508       1.105
+:erlang.put/2                                                     1000       3.235       3.235
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.164       3.136
+Task.Supervised.put_callers/1                                      250       3.010       0.898
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.286       2.271
+ExPng.RawData.from_file/1                                            1       2.143       0.006
+Task.get_owner/1                                                   250       1.975       0.662
+Enum.reverse/1                                                     494       1.971       1.068
+ExPng.RawData.from_chunks/2                                          1       1.780       0.006
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.607       1.554
+Enum.with_index/1                                                    3       1.521       0.003
+Enum.with_index/2                                                    3       1.518       0.006
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.511       1.507
+Enum.do_with_index/2                                               753       1.509       1.506
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.507       1.505
+Enumerable.impl_for!/1                                             485       1.501       1.012
+ExPng.Chunks.ImageData.merge/1                                       1       1.497       0.007
+:lists.reverse/2                                                   979       1.475       1.161
+:erlang.fun_info/2                                                 500       1.416       1.416
+:erlang.process_info/2                                             500       1.407       1.407
+ExPng.Image.Decoding.build_lines/1                                   1       1.358       0.004
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.345       1.012
+Process.info/2                                                     250       1.313       0.666
+:erlang.demonitor/2                                                254       1.147       0.643
+ExPng.Chunks.ImageData.inflate/1                                     1       0.999       0.007
+:zlib.inflate/2                                                      1       0.961       0.002
+:zlib.inflate/3                                                      1       0.959       0.008
+:proc_lib.trans_init/3                                             250       0.858       0.858
+Enum.drop/2                                                        245       0.802       0.276
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.785       0.019
+:zlib.inflate_nif/4                                                 12       0.766       0.766
+anonymous fn/2 in Enum.take/2                                      732       0.742       0.741
+anonymous fn/1 in Stream.cycle/1                                   732       0.740       0.740
+File.write/2                                                         1       0.632       0.002
+File.write/3                                                         1       0.630       0.008
+:file.write_file/3                                                   1       0.619       0.008
+:file.do_write_file/3                                                1       0.608       0.007
+Stream.cycle/1                                                     244       0.533       0.285
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.506       0.505
+:erts_internal.flush_monitor_messages/3                            251       0.494       0.471
+Enumerable.impl_for/1                                              485       0.488       0.488
+:proc_lib.get_ancestors/0                                          250       0.348       0.348
+:file.call/2                                                         2       0.346       0.011
+:erlang.monitor/2                                                  254       0.339       0.339
+:gen_server.call/3                                                   2       0.333       0.009
+:gen.call/4                                                          2       0.321       0.004
+Task.get_callers/1                                                 250       0.320       0.320
+:gen.do_for_proc/2                                                   2       0.317       0.009
+anonymous fn/4 in :gen.call/4                                        2       0.305       0.003
+:gen.do_call/4                                                       2       0.302       0.026
+ExPng.Image.Line.new/2                                             250       0.269       0.261
+:file.open/2                                                         1       0.256       0.011
+Stream.unfold/2                                                    244       0.248       0.248
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.244       0.244
+:erlang.max/2                                                      241       0.243       0.243
+ExPng.RawData.parse_chunks/2                                        11       0.209       0.067
+:file.close/1                                                        1       0.191       0.004
+:file.file_request/2                                                 1       0.187       0.010
+:erlang.crc32/1                                                     14       0.180       0.119
+:file.write/2                                                        1       0.154       0.005
+:io.request/2                                                        1       0.147       0.006
+:io.execute_request/2                                                1       0.139       0.012
+File.read/1                                                          1       0.128       0.004
+:file.read_file/1                                                    1       0.122       0.003
+:file.check_and_call/2                                               1       0.118       0.004
+ExPng.RawData.validate_crc/3                                        11       0.105       0.033
+ExPng.RawData.find_image_data/1                                      1       0.104       0.003
+Enum.split_with/2                                                    1       0.101       0.007
+ExPng.RawData.find_end/1                                             1       0.092       0.005
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.089       0.052
+Enum.reject/2                                                        2       0.087       0.003
+Enum.reject_list/2                                                  17       0.084       0.066
+ExPng.RawData.find_palette/2                                         1       0.081       0.003
+ExPng.RawData.find_chunk/2                                           2       0.078       0.004
+Enum.find/2                                                          2       0.074       0.003
+Enum.find/3                                                          2       0.071       0.003
+Enum.find_list/3                                                    16       0.068       0.051
+:zlib.append_iolist/2                                               41       0.053       0.053
+anonymous fn/3 in Enum.split_with/2                                 10       0.037       0.026
+:zlib.deflateInit/2                                                  1       0.035       0.002
+ExPng.Chunks.from_type/2                                            11       0.034       0.016
+:zlib.deflateInit/6                                                  1       0.033       0.011
+:zlib.enqueue_input/2                                                2       0.020       0.008
+ExPng.RawData.parse_ihdr/1                                           1       0.020       0.005
+ExPng.Chunks.Header.to_bytes/1                                       1       0.018       0.002
+:zlib.inflateInit/1                                                  1       0.017       0.001
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.017       0.017
+:zlib.inflateInit/2                                                  1       0.016       0.002
+:zlib.deflateInit_nif/6                                              1       0.016       0.016
+Keyword.get/3                                                        1       0.016       0.003
+ExPng.Chunks.Header.to_bytes/2                                       1       0.016       0.013
+:zlib.open/0                                                         2       0.015       0.003
+:zlib.inflateInit/3                                                  1       0.014       0.007
+:zlib.close/1                                                        2       0.014       0.004
+:erlang.binary_to_atom/2                                            10       0.014       0.014
+:lists.keyfind/3                                                     1       0.013       0.005
+:zlib.open_nif/0                                                     2       0.012       0.012
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.011       0.011
+:zlib.enqueue_input_1/2                                              2       0.010       0.006
+:zlib.close_nif/1                                                    2       0.010       0.007
+:erlang.send/3                                                       2       0.010       0.010
+:file.check_args/1                                                   6       0.009       0.009
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.009       0.009
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.009       0.009
+ExPng.Color.line_bytesize/1                                          1       0.009       0.001
+:zlib.restore_progress/2                                             2       0.008       0.005
+:zlib.exception_on_need_dict/2                                       1       0.008       0.004
+ExPng.Color.line_bytesize/3                                          1       0.008       0.003
+ExPng.Chunks.Header.new/2                                            1       0.008       0.006
+ExPng.Chunks.End.to_bytes/1                                          1       0.008       0.002
+:zlib.deflateEnd/1                                                   1       0.007       0.002
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Color.pixel_bitsize/2                                          2       0.007       0.005
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateEnd/1                                                   1       0.006       0.002
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Chunks.End.to_bytes/2                                          1       0.006       0.004
+:zlib.deflateEnd_nif/1                                               1       0.005       0.005
+:lists.member/2                                                      3       0.005       0.005
+ExPng.Image.Encoding.grayscale?/1                                    1       0.005       0.001
+ExPng.Image.Encoding.black_and_white?/1                              1       0.005       0.001
+:zlib.inflate_opts/0                                                 1       0.004       0.003
+:zlib.inflateInit_nif/3                                              1       0.004       0.004
+:zlib.inflateEnd_nif/1                                               1       0.004       0.004
+:zlib.enqueue_nif/2                                                  2       0.004       0.004
+:zlib.deflate_opts/1                                                 1       0.004       0.003
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.004       0.004
+:zlib.getStash_nif/1                                                 2       0.003       0.003
+:file.make_binary/1                                                  2       0.003       0.003
+:erlang.whereis/1                                                    2       0.003       0.003
+IO.chardata_to_string/1                                              2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.arg_level/1                                                    1       0.002       0.002
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_eos_behavior/1                                             1       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+:erlang.list_to_tuple/1                                              2       0.002       0.002
+:erlang.iolist_to_iovec/1                                            2       0.002       0.002
+File.normalize_modes/2                                               1       0.002       0.002
+ExPng.Color.to_bytesize/1                                            2       0.002       0.002
+ExPng.Color.channels_for_color_mode/1                                2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Image.Encoding.indexable?/1                                    1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite3.prof
+++ b/prof/readwrite3.prof
@@ -1,0 +1,271 @@
+Compiling 2 files (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2611606    4867.276    5343.241
+:proc_lib.init_p/5                                                 250   66722.048       4.056
+:suspend                                                          2124   66246.083       0.000
+:fprof.apply_start_stop/4                                            0    4867.276       0.010
+anonymous fn/0 in :elixir_compiler_3.__FILE__/1                      1    4867.262       0.005
+ExPng.Image.from_file/1                                              1    3108.262       0.005
+ExPng.Image.Decoding.from_raw_data/1                                 1    3106.011       0.010
+Enum.reduce/3                                                    63239    3081.164      68.675
+Enum."-reduce/3-lists^foldl/2-0-"/3                             186989    3080.638     518.948
+ExPng.Image.Decoding.filter_pass/2                                   1    2714.233       0.003
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2713.677       0.523
+ExPng.Image.Line.filter_pass/3                                     494    2713.153       2.865
+ExPng.Image.to_file/2                                                1    1758.995       0.001
+ExPng.Image.to_file/3                                                1    1758.994       0.004
+ExPng.Image.Encoding.to_raw_data/1                                   1    1734.629       0.004
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1205.619     189.582
+ExPng.Image.Encoding.build_header/1                                  1     954.504       0.002
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     954.502       0.005
+Enum.reduce_range_inc/4                                         187482     908.539     332.884
+Enum.map/2                                                           4     839.389       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     839.384       2.860
+ExPng.Chunks.ImageData.from_pixels/2                                 1     780.121       0.008
+ExPng.Image.unique_pixels/1                                          2     705.552       0.004
+List.flatten/1                                                       7     634.024       0.010
+:lists.flatten/1                                                     7     634.014       0.010
+:lists.do_flatten/2                                             315069     634.004     633.244
+Enumerable.reduce/3                                                485     633.661       1.027
+Enum.chunk_every/4                                                 241     631.272       0.241
+Stream.Reducers.chunk_every/5                                      241     631.031       0.483
+Enum."-fun.chunk_while/4-"/4                                       241     630.306       0.241
+Enum.chunk_while/4                                                 241     630.065       0.758
+Enumerable.List.reduce/3                                         60732     626.535     125.309
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     567.624     380.665
+:proc_lib.init_p_do_apply/3                                        250     509.944       1.144
+Task.Supervised.reply/4                                            250     508.800       1.584
+anonymous fn/3 in Enum.chunk_while/4                             60491     501.042     125.402
+Task.Supervised.reply/5                                            250     500.813       1.722
+Enum.uniq/1                                                          2     453.868       0.002
+Enum.uniq_by/2                                                       2     453.866       0.002
+Enum.uniq_list/3                                                125002     453.864     325.171
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     445.185       0.354
+Task.async/1                                                       250     444.831       0.336
+Task.async/3                                                       250     444.495       2.099
+Task.Supervised.start_link/4                                       250     405.144       0.661
+:proc_lib.spawn_link/3                                             250     404.476       1.470
+:erlang.spawn_link/3                                               250     400.729     400.729
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     389.289       0.500
+ExPng.Image.Encoding.indexable?/1                                    1     384.685       0.002
+ExPng.Image.Encoding.unique_pixel_count/1                            1     384.683       0.002
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     374.901     188.105
+Task.Supervised.invoke_mfa/2                                       250     369.571       0.910
+:erlang.apply/2                                                    250     368.661       0.581
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     368.080       0.533
+ExPng.Chunks.ImageData.line_to_binary/3                            250     367.547       0.607
+ExPng.Image.Encoding.opaque?/1                                       1     318.104       0.002
+ExPng.Image.Line.to_pixels/4                                       250     263.689       0.250
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     263.439     187.925
+Enum.take/2                                                      60744     257.474      64.952
+Enum.all?/2                                                          3     187.640       0.003
+Enum.all_list/2                                                  62503     187.637     125.054
+Enum.take_list/2                                                123501     186.838     186.199
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     182.314     181.809
+:erlang.send/2                                                     500     129.378     129.378
+anonymous fn/1 in Enum.uniq/1                                   125000     127.236     127.054
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     126.269     125.285
+Enum.zip/2                                                         241     125.878       0.261
+ExPng.Image.Encoding.black_and_white?/1                              1     125.861       0.002
+ExPng.Image.Encoding.grayscale?/1                                    1     125.847       0.002
+Enum.zip_list/2                                                  60491     125.617     125.311
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     125.544       3.601
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     124.508     123.772
+Enum.at/2                                                          751     113.119       0.863
+Enum.at/3                                                          751     112.245       1.642
+Enum.slice_any/3                                                   751     110.602       1.724
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500     108.935     108.935
+Enum.drop_list/2                                                 94616     108.238     108.071
+ExPng.Pixel.rgb/3                                                62500      75.429      62.590
+Range.new/2                                                      62494      64.332      63.254
+:lists.reverse/1                                                 60737      62.871      61.603
+ExPng.Pixel.opaque?/1                                            62500      62.532      62.516
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      60.899      60.671
+:garbage_collect                                                  4314      45.859      45.859
+:erlang.monitor/2                                                  255      34.472       0.590
+ExPng.RawData.to_file/3                                              1      24.361       0.031
+ExPng.Chunks.ImageData.to_bytes/2                                    1      23.886       0.015
+ExPng.Chunks.ImageData.deflate/2                                     1      23.663       0.044
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      21.878       4.933
+Enum.reduce/2                                                      254      17.703       0.278
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      17.425       8.736
+ExPng.Image.Line.build_pad_for_filter/1                            244      10.706       0.791
+ExPng.Utilities.reduce_to_binary/1                                   4      10.452       0.013
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               270       6.434       4.797
+:zlib.dequeue_all_chunks/2                                           2       6.030       0.003
+:zlib.dequeue_all_chunks_1/3                                        39       6.027       0.180
+:zlib.dequeue_next_chunk/2                                          39       5.275       0.042
+:zlib.deflate/3                                                      1       5.019       0.005
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       4.962       4.789
+:zlib."-fun.deflate_nif/4-"/4                                       27       4.703       0.028
+:zlib.deflate_nif/4                                                 27       4.675       4.675
+Task.Supervised.initial_call/1                                     250       4.658       1.019
+Enumerable.Function.reduce/3                                       244       4.623       0.268
+anonymous fn/4 in Stream.unfold/2                                  244       4.355       0.269
+Stream.do_unfold/4                                                 976       4.086       2.611
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.458       3.405
+Process.put/2                                                      500       2.517       1.714
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.436       2.377
+Task.Supervised.get_initial_call/1                                 250       2.374       1.495
+ExPng.RawData.from_file/1                                            1       2.246       0.005
+:erlang.put/2                                                     1000       2.074       2.074
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       2.046       0.340
+Task.get_owner/1                                                   250       2.013       0.639
+:proc_lib.get_my_name/0                                            250       1.917       0.740
+ExPng.RawData.from_chunks/2                                          1       1.795       0.006
+Task.Supervised.put_callers/1                                      250       1.745       0.493
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.718       1.711
+ExPng.Image.Decoding.build_lines/1                                   1       1.711       0.005
+Task.await/1                                                       250       1.706       0.348
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.691       1.273
+Enum.with_index/1                                                    3       1.626       0.003
+Enum.with_index/2                                                    3       1.623       0.006
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.616       1.576
+Enum.do_with_index/2                                               753       1.614       1.602
+ExPng.Chunks.ImageData.merge/1                                       1       1.607       0.007
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.595       1.592
+Enumerable.impl_for!/1                                             485       1.476       0.987
+Process.info/2                                                     250       1.374       0.656
+:lists.reverse/2                                                   735       1.359       0.938
+Task.await/2                                                       250       1.358       0.681
+:proc_lib.proc_info/2                                              250       1.177       0.765
+:erlang.process_info/2                                             500       1.130       1.130
+ExPng.Chunks.ImageData.inflate/1                                     1       1.089       0.007
+:zlib.inflate/2                                                      1       1.061       0.001
+:zlib.inflate/3                                                      1       1.060       0.008
+:erlang.fun_info/2                                                 500       0.879       0.879
+Enum.reverse/1                                                     250       0.865       0.534
+Enum.drop/2                                                        245       0.800       0.280
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.765       0.756
+anonymous fn/1 in Stream.cycle/1                                   732       0.739       0.738
+anonymous fn/2 in Enum.take/2                                      732       0.736       0.736
+:erlang.demonitor/2                                                254       0.691       0.357
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.613       0.514
+:proc_lib.trans_init/3                                             250       0.603       0.603
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.530       0.015
+Stream.cycle/1                                                     244       0.520       0.273
+:zlib.inflate_nif/4                                                 12       0.515       0.515
+Enumerable.impl_for/1                                              485       0.489       0.489
+File.write/2                                                         1       0.422       0.002
+File.write/3                                                         1       0.420       0.009
+:file.write_file/3                                                   1       0.409       0.006
+:file.do_write_file/3                                                1       0.400       0.008
+:file.call/2                                                         2       0.379       0.009
+:gen_server.call/3                                                   2       0.367       0.009
+:proc_lib.get_ancestors/0                                          250       0.360       0.360
+:gen.call/4                                                          2       0.348       0.005
+:gen.do_for_proc/2                                                   2       0.343       0.008
+Task.get_callers/1                                                 250       0.339       0.339
+anonymous fn/4 in :gen.call/4                                        2       0.332       0.003
+:gen.do_call/4                                                       2       0.329       0.025
+:erts_internal.flush_monitor_messages/3                            250       0.328       0.328
+ExPng.Image.Line.new/2                                             250       0.317       0.317
+Stream.unfold/2                                                    244       0.247       0.247
+ExPng.RawData.parse_chunks/2                                        11       0.247       0.042
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.242       0.242
+:erlang.max/2                                                      241       0.241       0.241
+:file.open/2                                                         1       0.228       0.010
+File.read/1                                                          1       0.184       0.002
+:file.read_file/1                                                    1       0.181       0.002
+:file.check_and_call/2                                               1       0.178       0.002
+ExPng.RawData.validate_crc/3                                        11       0.177       0.025
+:erlang.crc32/1                                                     14       0.163       0.133
+:file.write/2                                                        1       0.090       0.007
+Keyword.get/3                                                        1       0.083       0.003
+:io.request/2                                                        1       0.082       0.006
+:lists.keyfind/3                                                     1       0.080       0.003
+:io.execute_request/2                                                1       0.074       0.011
+:file.close/1                                                        1       0.074       0.003
+:file.file_request/2                                                 1       0.071       0.011
+ExPng.RawData.find_end/1                                             1       0.063       0.003
+Enum.reject/2                                                        2       0.063       0.002
+ExPng.RawData.find_image_data/1                                      1       0.061       0.002
+Enum.reject_list/2                                                  17       0.061       0.046
+Enum.split_with/2                                                    1       0.059       0.004
+ExPng.RawData.find_palette/2                                         1       0.058       0.003
+ExPng.RawData.find_chunk/2                                           2       0.052       0.002
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.051       0.021
+Enum.find/2                                                          2       0.050       0.002
+Enum.find/3                                                          2       0.048       0.002
+Enum.find_list/3                                                    16       0.046       0.031
+:zlib.append_iolist/2                                               41       0.045       0.045
+:zlib.deflateInit/2                                                  1       0.038       0.001
+:zlib.deflateInit/6                                                  1       0.037       0.007
+anonymous fn/3 in Enum.split_with/2                                 10       0.030       0.020
+ExPng.Chunks.from_type/2                                            11       0.027       0.011
+:zlib.deflateInit_nif/6                                              1       0.025       0.025
+:zlib.deflateEnd/1                                                   1       0.024       0.001
+:zlib.deflateEnd_nif/1                                               1       0.023       0.023
+ExPng.RawData.parse_ihdr/1                                           1       0.015       0.003
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.015       0.015
+ExPng.Color.line_bytesize/1                                          1       0.015       0.002
+ExPng.Chunks.Header.to_bytes/1                                       1       0.015       0.002
+:zlib.enqueue_input/2                                                2       0.014       0.004
+ExPng.Color.line_bytesize/3                                          1       0.013       0.004
+ExPng.Chunks.Header.to_bytes/2                                       1       0.013       0.007
+:zlib.close/1                                                        2       0.012       0.004
+:file.check_args/1                                                   6       0.011       0.011
+ExPng.Color.pixel_bitsize/2                                          2       0.011       0.008
+:zlib.exception_on_need_dict/2                                       1       0.010       0.005
+:erlang.binary_to_atom/2                                            10       0.010       0.010
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.010       0.010
+:zlib.restore_progress/2                                             2       0.008       0.005
+:zlib.open/0                                                         2       0.008       0.003
+:zlib.inflateInit/1                                                  1       0.008       0.001
+:zlib.enqueue_input_1/2                                              2       0.008       0.004
+:zlib.close_nif/1                                                    2       0.008       0.006
+:erlang.send/3                                                       2       0.008       0.008
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.008       0.008
+:zlib.inflateInit/2                                                  1       0.007       0.001
+:zlib.inflateEnd/1                                                   1       0.007       0.002
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.007       0.007
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Chunks.End.to_bytes/1                                          1       0.007       0.001
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateInit/3                                                  1       0.006       0.003
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Chunks.Header.new/2                                            1       0.006       0.004
+ExPng.Chunks.End.to_bytes/2                                          1       0.006       0.004
+:zlib.open_nif/0                                                     2       0.005       0.005
+:zlib.inflateEnd_nif/1                                               1       0.005       0.005
+:lists.member/2                                                      3       0.005       0.005
+:zlib.enqueue_nif/2                                                  2       0.004       0.004
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.004       0.004
+:zlib.inflate_opts/0                                                 1       0.003       0.002
+:zlib.getStash_nif/1                                                 2       0.003       0.003
+:zlib.deflate_opts/1                                                 1       0.003       0.002
+:erlang.whereis/1                                                    2       0.003       0.003
+:erlang.list_to_tuple/1                                              2       0.003       0.003
+ExPng.Color.channels_for_color_mode/1                                2       0.003       0.003
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.003       0.003
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:file.make_binary/1                                                  2       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+:erlang.iolist_to_iovec/1                                            2       0.002       0.002
+IO.chardata_to_string/1                                              2       0.002       0.002
+ExPng.Color.to_bytesize/1                                            2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.inflateInit_nif/3                                              1       0.001       0.001
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+:zlib.arg_level/1                                                    1       0.001       0.001
+:zlib.arg_eos_behavior/1                                             1       0.001       0.001
+File.normalize_modes/2                                               1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite5.prof
+++ b/prof/readwrite5.prof
@@ -1,0 +1,259 @@
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                         17800594   27757.487   27947.779
+:proc_lib.init_p/5                                                 250   41119.151       3.573
+:suspend                                                          7208   40928.859       0.000
+:fprof.apply_start_stop/4                                            0   27757.487       0.009
+anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1   27757.476       0.004
+ExPng.Image.from_file/1                                              1   25790.098       0.005
+ExPng.Image.Decoding.from_raw_data/1                                 1   25787.510       0.011
+Enum.reduce/3                                                    63239   25575.374      91.115
+Enum."-reduce/3-lists^foldl/2-0-"/3                             186989   25574.990     517.179
+ExPng.Image.Decoding.filter_pass/1                                   1   25302.862       0.005
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/1               250   25302.069       1.051
+ExPng.Image.Line.filter_pass/3                                     494   25298.558       3.322
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                 60250   24273.877     380.279
+Enum.at/2                                                       121010   22715.274     168.904
+Enum.at/3                                                       121010   22525.802     300.086
+Enum.slice_any/3                                                121010   22207.227     327.935
+Enum.drop_list/2                                              15157116   21642.090   21497.061
+ExPng.Image.to_file/2                                                1    1967.374       0.001
+ExPng.Image.to_file/3                                                1    1967.373       0.006
+ExPng.Image.Encoding.to_raw_data/1                                   1    1961.633       0.005
+Enum.reduce_range_inc/4                                         187482    1129.638     429.526
+ExPng.Image.Encoding.build_header/1                                  1    1039.974       0.004
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1    1039.970       0.007
+ExPng.Chunks.ImageData.from_pixels/2                                 1     921.654       0.013
+ExPng.Image.unique_pixels/1                                          2     885.287       0.006
+Enum.map/2                                                           4     880.085       0.011
+Enum."-map/2-lists^map/1-0-"/2                                     756     880.074       3.397
+List.flatten/1                                                       7     820.656       0.013
+:lists.flatten/1                                                     7     820.643       0.013
+:lists.do_flatten/2                                             315069     820.630     769.294
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     684.778     471.408
+Enum.uniq/1                                                          2     540.193       0.002
+Enum.uniq_by/2                                                       2     540.191       0.002
+Enum.uniq_list/3                                                125002     540.189     391.641
+anonymous fn/3 in ExPng.Image.Decoding.from_raw_data/1             250     482.254       0.532
+:proc_lib.init_p_do_apply/3                                        250     383.921       1.147
+Task.Supervised.reply/4                                            250     382.774       1.835
+Task.Supervised.reply/5                                            250     373.756       1.421
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     373.307       0.398
+Task.async/1                                                       250     372.909       0.398
+Task.async/3                                                       250     372.511       2.610
+Enum.take_list/2                                                183510     366.197     264.653
+Task.Supervised.start_link/4                                       250     366.132       0.793
+:proc_lib.spawn_link/3                                             250     365.339       1.735
+ExPng.Image.Encoding.indexable?/1                                    1     364.109       0.002
+ExPng.Image.Encoding.unique_pixel_count/1                            1     364.107       0.002
+:erlang.spawn_link/3                                               250     360.565     360.565
+:garbage_collect                                                  8069     353.057     353.057
+ExPng.Image.Line.to_pixels/4                                       250     348.835       0.263
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     348.571     195.436
+ExPng.Image.Encoding.opaque?/1                                       1     326.280       0.002
+Task.Supervised.invoke_mfa/2                                       250     274.990       0.812
+:erlang.apply/2                                                    250     274.178       0.566
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     273.612       0.529
+ExPng.Chunks.ImageData.line_to_binary/3                            250     273.083       0.556
+ExPng.Image.Encoding.grayscale?/1                                    1     210.536       0.006
+Enum.all?/2                                                          3     200.470       0.004
+Enum.all_list/2                                                  62503     200.466     136.926
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     195.288     193.530
+ExPng.Pixel.rgb/3                                                62500     152.880      63.375
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     152.123     148.894
+Enum.take/2                                                        494     142.514       1.123
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     139.410       3.395
+Enum.with_index/1                                                  244     139.129       0.270
+ExPng.Image.Encoding.black_and_white?/1                              1     139.038       0.002
+Enum.with_index/2                                                  244     138.859       0.539
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     138.723     136.392
+Enum.do_with_index/2                                             61244     138.072     137.065
+anonymous fn/1 in Enum.uniq/1                                   125000     129.241     128.886
+Range.new/2                                                      62494     109.871      71.733
+:erlang.send/2                                                     501      97.842      97.821
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500      82.134      82.134
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      66.005      64.298
+ExPng.Pixel.opaque?/1                                            62500      63.389      63.294
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      26.014       5.818
+ExPng.Image.Line.build_pad_for_filter/1                            244      14.287       1.155
+Enum.reduce/2                                                      254      12.734       0.408
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      12.326       6.948
+Enumerable.reduce/3                                                244       7.702       0.845
+:zlib.dequeue_all_chunks/2                                           2       6.186       0.004
+:zlib.dequeue_all_chunks_1/3                                        39       6.182       0.266
+Enumerable.Function.reduce/3                                       244       5.951       0.372
+ExPng.RawData.to_file/3                                              1       5.734       0.010
+:zlib.dequeue_next_chunk/2                                          39       5.609       0.074
+anonymous fn/4 in Stream.unfold/2                                  244       5.579       0.396
+ExPng.Chunks.ImageData.to_bytes/2                                    1       5.358       0.010
+ExPng.Chunks.ImageData.deflate/2                                     1       5.274       0.008
+Task.Supervised.initial_call/1                                     250       5.272       1.318
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       5.256       5.022
+Stream.do_unfold/4                                                 976       5.183       3.598
+:zlib.deflate/3                                                      1       5.082       0.007
+:zlib."-fun.deflate_nif/4-"/4                                       27       4.627       0.040
+:zlib.deflate_nif/4                                                 27       4.587       4.587
+ExPng.Utilities.reduce_to_binary/1                                   4       3.861       0.015
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.769       3.753
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               270       2.873       2.642
+Process.put/2                                                      500       2.744       1.932
+ExPng.RawData.from_file/1                                            1       2.583       0.012
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.536       2.479
+Task.Supervised.get_initial_call/1                                 250       2.532       1.678
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       2.490       0.438
+Task.get_owner/1                                                   250       2.465       0.819
+ExPng.Color.pixel_bytesize/1                                       250       2.460       0.530
+:proc_lib.get_my_name/0                                            250       2.176       0.849
+ExPng.RawData.from_chunks/2                                          1       2.160       0.011
+Task.await/1                                                       250       2.052       0.427
+ExPng.Color.pixel_bytesize/2                                       250       1.930       0.719
+Task.Supervised.put_callers/1                                      250       1.911       0.589
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.881       1.702
+:erlang.put/2                                                     1000       1.844       1.844
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.823       1.805
+ExPng.Chunks.ImageData.merge/1                                       1       1.769       0.014
+Process.info/2                                                     250       1.646       0.783
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.646       1.644
+Task.await/2                                                       250       1.625       0.813
+ExPng.Image.Decoding.build_lines/1                                   1       1.602       0.006
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.583       1.202
+Enum.reverse/1                                                     250       1.504       0.824
+:proc_lib.proc_info/2                                              250       1.327       0.913
+:erlang.process_info/2                                             500       1.277       1.268
+ExPng.Chunks.ImageData.inflate/1                                     1       1.234       0.014
+:zlib.inflate/2                                                      1       1.180       0.002
+:zlib.inflate/3                                                      1       1.178       0.013
+:lists.reverse/1                                                   246       1.070       0.712
+Enum.drop/2                                                        245       1.023       0.395
+:lists.reverse/2                                                   494       0.941       0.885
+ExPng.Color.pixel_bitsize/2                                        251       0.927       0.655
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.908       0.030
+Enumerable.impl_for!/1                                             244       0.906       0.644
+:zlib.inflate_nif/4                                                 12       0.878       0.878
+:proc_lib.get_ancestors/0                                          250       0.863       0.863
+:erlang.fun_info/2                                                 500       0.854       0.854
+:erlang.demonitor/2                                                254       0.822       0.447
+anonymous fn/1 in Stream.cycle/1                                   732       0.800       0.800
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.794       0.775
+anonymous fn/2 in Enum.take/2                                      732       0.779       0.779
+Stream.cycle/1                                                     244       0.756       0.487
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.640       0.640
+:proc_lib.trans_init/3                                             250       0.496       0.496
+:erlang.monitor/2                                                  254       0.419       0.419
+Task.get_callers/1                                                 250       0.395       0.395
+:erts_internal.flush_monitor_messages/3                            251       0.375       0.375
+File.write/2                                                         1       0.350       0.002
+File.write/3                                                         1       0.348       0.005
+ExPng.Image.Line.new/2                                             250       0.348       0.332
+:file.write_file/3                                                   1       0.341       0.004
+:file.do_write_file/3                                                1       0.335       0.006
+ExPng.Color.to_bytesize/1                                          251       0.290       0.290
+ExPng.RawData.parse_chunks/2                                        11       0.278       0.088
+Stream.unfold/2                                                    244       0.269       0.269
+ExPng.Color.channels_for_color_mode/1                              251       0.266       0.266
+Enumerable.impl_for/1                                              244       0.262       0.262
+Enum.to_list/1                                                     244       0.247       0.247
+:file.call/2                                                         2       0.246       0.009
+:gen_server.call/3                                                   2       0.235       0.007
+:gen.call/4                                                          2       0.228       0.004
+:gen.do_for_proc/2                                                   2       0.224       0.006
+anonymous fn/4 in :gen.call/4                                        2       0.214       0.003
+:gen.do_call/4                                                       2       0.211       0.023
+:file.open/2                                                         1       0.170       0.005
+ExPng.RawData.find_image_data/1                                      1       0.142       0.004
+Enum.split_with/2                                                    1       0.138       0.008
+:erlang.crc32/1                                                     14       0.136       0.122
+Enum.reject/2                                                        2       0.123       0.005
+ExPng.RawData.find_end/1                                             1       0.122       0.005
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.122       0.052
+Enum.reject_list/2                                                  17       0.118       0.087
+ExPng.RawData.validate_crc/3                                        11       0.116       0.040
+ExPng.RawData.find_palette/2                                         1       0.116       0.005
+File.read/1                                                          1       0.105       0.003
+ExPng.RawData.find_chunk/2                                           2       0.105       0.006
+:file.read_file/1                                                    1       0.100       0.004
+Enum.find/2                                                          2       0.099       0.004
+:file.check_and_call/2                                               1       0.095       0.003
+Enum.find/3                                                          2       0.095       0.005
+Enum.find_list/3                                                    16       0.090       0.064
+:file.close/1                                                        1       0.081       0.003
+:file.write/2                                                        1       0.078       0.004
+:file.file_request/2                                                 1       0.078       0.009
+:io.request/2                                                        1       0.072       0.004
+ExPng.Chunks.from_type/2                                            11       0.072       0.027
+anonymous fn/3 in Enum.split_with/2                                 10       0.070       0.042
+:io.execute_request/2                                                1       0.066       0.007
+:zlib.append_iolist/2                                               41       0.052       0.052
+ExPng.Chunks.Ancillary.new/2                                         7       0.031       0.019
+:zlib.deflateInit/2                                                  1       0.028       0.002
+ExPng.RawData.parse_ihdr/1                                           1       0.028       0.008
+:zlib.deflateInit/6                                                  1       0.026       0.007
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.026       0.026
+:zlib.enqueue_input/2                                                2       0.022       0.007
+:zlib.inflateInit/1                                                  1       0.020       0.002
+:zlib.inflateInit/2                                                  1       0.018       0.003
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.018       0.018
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.018       0.018
+:zlib.close/1                                                        2       0.017       0.004
+:erlang.binary_to_atom/2                                            10       0.016       0.016
+:zlib.inflateInit/3                                                  1       0.015       0.006
+:zlib.exception_on_need_dict/2                                       1       0.015       0.008
+:zlib.open/0                                                         2       0.014       0.004
+:zlib.deflateInit_nif/6                                              1       0.013       0.013
+:zlib.close_nif/1                                                    2       0.013       0.007
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.013       0.013
+ExPng.Color.line_bytesize/1                                          1       0.013       0.002
+:zlib.enqueue_input_1/2                                              2       0.012       0.006
+Keyword.get/3                                                        1       0.012       0.002
+ExPng.Color.line_bytesize/3                                          1       0.011       0.005
+ExPng.Chunks.Header.to_bytes/1                                       1       0.011       0.001
+ExPng.Chunks.Header.new/2                                            1       0.011       0.008
+:zlib.restore_progress/2                                             2       0.010       0.006
+:zlib.open_nif/0                                                     2       0.010       0.010
+:lists.keyfind/3                                                     1       0.010       0.004
+:erlang.send/3                                                       2       0.010       0.010
+ExPng.Chunks.Header.to_bytes/2                                       1       0.010       0.007
+:zlib.inflateEnd/1                                                   1       0.008       0.004
+:file.check_args/1                                                   6       0.008       0.008
+:zlib.inflate_opts/0                                                 1       0.006       0.005
+:zlib.enqueue_nif/2                                                  2       0.006       0.006
+:zlib.inflateInit_nif/3                                              1       0.005       0.005
+:zlib.deflateEnd/1                                                   1       0.005       0.001
+ExPng.Chunks.End.to_bytes/1                                          1       0.005       0.002
+:zlib.inflateEnd_nif/1                                               1       0.004       0.004
+:zlib.getStash_nif/1                                                 2       0.004       0.004
+:zlib.deflate_opts/1                                                 1       0.004       0.003
+:zlib.deflateEnd_nif/1                                               1       0.004       0.004
+:erlang.whereis/1                                                    2       0.004       0.004
+:zlib.arg_bitsz/1                                                    2       0.003       0.003
+:lists.member/2                                                      3       0.003       0.003
+:file.make_binary/1                                                  2       0.003       0.003
+:erlang.iolist_to_iovec/1                                            2       0.003       0.003
+IO.chardata_to_string/1                                              2       0.003       0.003
+ExPng.Pixel.grayscale?/1                                             1       0.003       0.003
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.003       0.003
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.003       0.003
+ExPng.Chunks.End.to_bytes/2                                          1       0.003       0.002
+:zlib.proplist_get_value/3                                           1       0.002       0.002
+:zlib.arg_level/1                                                    1       0.002       0.002
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_eos_behavior/1                                             1       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+:erlang.list_to_tuple/1                                              2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+File.normalize_modes/2                                               1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite6.prof
+++ b/prof/readwrite6.prof
@@ -1,0 +1,270 @@
+Compiling 3 files (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2611611    4960.952    5404.668
+:proc_lib.init_p/5                                                 250   51785.392       3.317
+:suspend                                                          2094   51341.676       0.000
+:fprof.apply_start_stop/4                                            0    4960.952       0.009
+anonymous fn/0 in :elixir_compiler_2.__FILE__/1                      1    4960.941       0.006
+ExPng.Image.from_file/1                                              1    3171.721       0.006
+ExPng.Image.Decoding.from_raw_data/1                                 1    3169.959       0.011
+Enum.reduce/3                                                    63239    3080.304      70.303
+Enum."-reduce/3-lists^foldl/2-0-"/3                             186989    3079.927     479.503
+ExPng.Image.Decoding.filter_pass/2                                   1    2778.819       0.004
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2778.247       0.535
+ExPng.Image.Line.filter_pass/3                                     494    2777.699       2.928
+ExPng.Image.to_file/2                                                1    1789.214       0.001
+ExPng.Image.to_file/3                                                1    1789.213       0.003
+ExPng.Image.Encoding.to_raw_data/1                                   1    1763.456       0.005
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1225.455     192.389
+ExPng.Image.Encoding.build_header/1                                  1     973.434       0.002
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     973.432       0.005
+Enum.reduce_range_inc/4                                         187482     924.570     341.041
+Enum.map/2                                                           4     849.124       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     849.119       3.559
+ExPng.Chunks.ImageData.from_pixels/2                                 1     790.017       0.009
+ExPng.Image.unique_pixels/1                                          2     696.077       0.004
+List.flatten/1                                                       7     651.781       0.012
+:lists.flatten/1                                                     7     651.769       0.009
+:lists.do_flatten/2                                             315069     651.760     649.246
+Enumerable.reduce/3                                                485     644.084       1.042
+Enum.chunk_every/4                                                 241     641.505       0.242
+Stream.Reducers.chunk_every/5                                      241     641.262       0.482
+Enum."-fun.chunk_while/4-"/4                                       241     640.537       0.241
+Enum.chunk_while/4                                                 241     640.296       0.763
+Enumerable.List.reduce/3                                         60732     636.814     128.165
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     575.241     386.685
+anonymous fn/3 in Enum.chunk_while/4                             60491     508.279     127.181
+:proc_lib.init_p_do_apply/3                                        250     466.803       1.107
+Task.Supervised.reply/4                                            250     465.696       1.441
+Task.Supervised.reply/5                                            250     458.300       1.261
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     453.206       0.366
+Task.async/1                                                       250     452.840       0.368
+Task.async/3                                                       250     452.472       2.490
+Task.Supervised.start_link/4                                       250     446.047       0.727
+:proc_lib.spawn_link/3                                             250     445.320       1.578
+Enum.uniq/1                                                          2     444.385       0.002
+Enum.uniq_by/2                                                       2     444.383       0.002
+Enum.uniq_list/3                                                125002     444.381     315.758
+:erlang.spawn_link/3                                               251     440.558     418.681
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     388.577       0.500
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     380.422     191.237
+ExPng.Image.Encoding.indexable?/1                                    1     375.204       0.002
+ExPng.Image.Encoding.unique_pixel_count/1                            1     375.202       0.002
+ExPng.Image.Encoding.opaque?/1                                       1     346.519       0.002
+Task.Supervised.invoke_mfa/2                                       250     303.279       0.661
+:erlang.apply/2                                                    250     302.618       0.364
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     302.254       0.361
+ExPng.Chunks.ImageData.line_to_binary/3                            250     301.893       0.398
+ExPng.Image.Line.to_pixels/4                                       250     262.707       0.250
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     262.457     188.382
+Enum.take/2                                                      60744     259.816      66.577
+Enum.all?/2                                                          3     198.314       0.003
+Enum.all_list/2                                                  62503     198.311     126.088
+Enum.take_list/2                                                123501     187.218     186.650
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     183.235     182.837
+:erlang.send/2                                                     500     154.205     154.193
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     146.121       3.625
+Enum.at/2                                                          751     132.514       1.000
+Enum.at/3                                                          751     131.514       1.806
+Enum.slice_any/3                                                   751     129.664       1.950
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     128.828     127.514
+anonymous fn/1 in Enum.uniq/1                                   125000     127.460     127.344
+Enum.drop_list/2                                                 94616     127.149     126.819
+Enum.zip/2                                                         241     127.060       0.265
+Enum.zip_list/2                                                  60491     126.795     126.409
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     126.768     125.835
+ExPng.Image.Encoding.black_and_white?/1                              1     125.857       0.002
+ExPng.Image.Encoding.grayscale?/1                                    1     125.847       0.002
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500      89.931      89.931
+ExPng.Pixel.rgb/3                                                62500      69.777      62.624
+Range.new/2                                                      62494      64.830      63.571
+:lists.reverse/1                                                 60737      63.258      61.831
+ExPng.Pixel.opaque?/1                                            62500      62.681      62.654
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      61.224      60.992
+:garbage_collect                                                  4347      59.313      59.313
+ExPng.RawData.to_file/3                                              1      25.754       0.020
+ExPng.Chunks.ImageData.to_bytes/2                                    1      25.404       0.013
+ExPng.Chunks.ImageData.deflate/2                                     1      25.297       0.040
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      22.198       4.982
+Enum.reduce/2                                                      254      16.328       0.291
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      16.037       7.371
+ExPng.Image.Line.build_pad_for_filter/1                            244      10.916       0.827
+ExPng.Utilities.reduce_to_binary/1                                   4       9.605       0.012
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               270       6.583       4.506
+:zlib.dequeue_all_chunks/2                                           2       5.989       0.002
+:zlib.dequeue_all_chunks_1/3                                        39       5.987       0.197
+:zlib.dequeue_next_chunk/2                                          39       5.529       0.050
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       5.141       4.965
+:zlib.deflate/3                                                      1       5.117       0.005
+:zlib."-fun.deflate_nif/4-"/4                                       27       4.732       0.033
+Enumerable.Function.reduce/3                                       244       4.732       0.274
+:zlib.deflate_nif/4                                                 27       4.699       4.699
+Task.Supervised.initial_call/1                                     250       4.477       1.031
+anonymous fn/4 in Stream.unfold/2                                  244       4.458       0.277
+Stream.do_unfold/4                                                 976       4.181       2.695
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       3.775       0.731
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.334       3.300
+Task.await/1                                                       250       3.044       0.725
+Task.get_owner/1                                                   250       2.630       0.846
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.592       2.507
+Task.await/2                                                       250       2.309       1.192
+Task.Supervised.get_initial_call/1                                 250       2.258       1.429
+Process.put/2                                                      500       2.247       1.529
+:proc_lib.get_my_name/0                                            250       2.011       0.813
+:erlang.put/2                                                     1000       1.816       1.816
+ExPng.Image.Decoding.build_lines/1                                   1       1.786       0.004
+Process.info/2                                                     250       1.784       0.765
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.768       1.274
+ExPng.RawData.from_file/1                                            1       1.756       0.007
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.753       1.729
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.718       1.645
+Enum.with_index/1                                                    3       1.651       0.003
+Enum.with_index/2                                                    3       1.648       0.006
+Enum.do_with_index/2                                               753       1.639       1.638
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.568       1.509
+:lists.reverse/2                                                   736       1.515       0.994
+Enumerable.impl_for!/1                                             485       1.495       1.000
+Task.Supervised.put_callers/1                                      250       1.478       0.419
+ExPng.RawData.from_chunks/2                                          1       1.457       0.005
+:erlang.process_info/2                                             500       1.415       1.408
+ExPng.Chunks.ImageData.merge/1                                       1       1.262       0.010
+:proc_lib.proc_info/2                                              250       1.198       0.802
+:erlang.demonitor/2                                                254       1.140       0.747
+Enum.reverse/1                                                     250       1.087       0.550
+ExPng.Chunks.ImageData.inflate/1                                     1       0.978       0.018
+:zlib.inflate/2                                                      1       0.926       0.001
+:zlib.inflate/3                                                      1       0.925       0.009
+:erlang.fun_info/2                                                 500       0.829       0.829
+Enum.drop/2                                                        245       0.797       0.275
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.796       0.775
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.747       0.021
+anonymous fn/1 in Stream.cycle/1                                   732       0.743       0.743
+anonymous fn/2 in Enum.take/2                                      732       0.742       0.741
+:zlib.inflate_nif/4                                                 12       0.726       0.726
+Stream.cycle/1                                                     244       0.530       0.280
+:proc_lib.trans_init/3                                             250       0.509       0.509
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.508       0.508
+Enumerable.impl_for/1                                              485       0.495       0.493
+:erlang.monitor/2                                                  254       0.480       0.480
+:erts_internal.flush_monitor_messages/3                            251       0.387       0.387
+:proc_lib.get_ancestors/0                                          250       0.382       0.382
+Task.get_callers/1                                                 250       0.378       0.378
+ExPng.Image.Line.new/2                                             250       0.374       0.374
+File.write/2                                                         1       0.314       0.001
+File.write/3                                                         1       0.313       0.007
+:file.write_file/3                                                   1       0.304       0.004
+:file.do_write_file/3                                                1       0.298       0.004
+:file.call/2                                                         2       0.264       0.012
+Stream.unfold/2                                                    244       0.250       0.249
+:gen_server.call/3                                                   2       0.249       0.008
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.245       0.244
+:erlang.max/2                                                      241       0.243       0.242
+:gen.call/4                                                          2       0.239       0.005
+:gen.do_for_proc/2                                                   2       0.234       0.008
+anonymous fn/4 in :gen.call/4                                        2       0.222       0.003
+:gen.do_call/4                                                       2       0.219       0.025
+:file.open/2                                                         1       0.169       0.007
+ExPng.RawData.parse_chunks/2                                        11       0.142       0.044
+File.read/1                                                          1       0.133       0.005
+:file.read_file/1                                                    1       0.125       0.006
+:erlang.crc32/1                                                     14       0.123       0.105
+:file.check_and_call/2                                               1       0.118       0.004
+ExPng.RawData.find_image_data/1                                      1       0.068       0.002
+ExPng.RawData.validate_crc/3                                        11       0.067       0.025
+Enum.split_with/2                                                    1       0.066       0.004
+:file.close/1                                                        1       0.064       0.002
+ExPng.RawData.find_end/1                                             1       0.064       0.003
+Enum.reject/2                                                        2       0.064       0.002
+:file.file_request/2                                                 1       0.062       0.007
+Enum.reject_list/2                                                  17       0.062       0.047
+:file.write/2                                                        1       0.061       0.003
+ExPng.RawData.find_palette/2                                         1       0.058       0.003
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.058       0.022
+:io.request/2                                                        1       0.057       0.004
+:io.execute_request/2                                                1       0.052       0.006
+ExPng.RawData.find_chunk/2                                           2       0.052       0.002
+Enum.find/2                                                          2       0.050       0.002
+:zlib.append_iolist/2                                               41       0.048       0.048
+Enum.find/3                                                          2       0.048       0.002
+Enum.find_list/3                                                    16       0.046       0.031
+:zlib.deflateInit/2                                                  1       0.038       0.001
+:zlib.deflateInit/6                                                  1       0.037       0.006
+anonymous fn/3 in Enum.split_with/2                                 10       0.036       0.026
+:zlib.deflateEnd/1                                                   1       0.035       0.001
+:zlib.deflateEnd_nif/1                                               1       0.034       0.034
+ExPng.Chunks.from_type/2                                            11       0.030       0.013
+:zlib.deflateInit_nif/6                                              1       0.026       0.026
+:zlib.inflateEnd/1                                                   1       0.019       0.003
+ExPng.RawData.parse_ihdr/1                                           1       0.017       0.004
+:zlib.inflateEnd_nif/1                                               1       0.016       0.016
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.015       0.015
+:zlib.exception_on_need_dict/2                                       1       0.014       0.006
+:zlib.close/1                                                        2       0.014       0.004
+ExPng.Color.line_bytesize/1                                          1       0.014       0.003
+:zlib.enqueue_input/2                                                2       0.013       0.004
+Keyword.get/3                                                        1       0.013       0.003
+:erlang.send/3                                                       2       0.012       0.012
+ExPng.Color.line_bytesize/3                                          1       0.011       0.004
+ExPng.Chunks.Header.to_bytes/1                                       1       0.011       0.002
+:zlib.restore_progress/2                                             2       0.010       0.008
+:zlib.open/0                                                         2       0.010       0.002
+:zlib.close_nif/1                                                    2       0.010       0.008
+:lists.keyfind/3                                                     1       0.010       0.004
+:erlang.binary_to_atom/2                                            10       0.010       0.010
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.010       0.010
+:file.check_args/1                                                   6       0.009       0.009
+ExPng.Chunks.Header.to_bytes/2                                       1       0.009       0.006
+:zlib.open_nif/0                                                     2       0.008       0.008
+:zlib.inflateInit/1                                                  1       0.008       0.001
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.008       0.008
+ExPng.Color.pixel_bitsize/2                                          2       0.008       0.005
+:zlib.inflateInit/2                                                  1       0.007       0.001
+:zlib.enqueue_input_1/2                                              2       0.007       0.004
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.007       0.007
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Chunks.Header.new/2                                            1       0.007       0.005
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateInit/3                                                  1       0.006       0.003
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Chunks.End.to_bytes/1                                          1       0.005       0.001
+:erlang.whereis/1                                                    2       0.004       0.004
+IO.chardata_to_string/1                                              2       0.004       0.004
+ExPng.Chunks.End.to_bytes/2                                          1       0.004       0.003
+:zlib.inflate_opts/0                                                 1       0.003       0.002
+:zlib.enqueue_nif/2                                                  2       0.003       0.003
+:zlib.deflate_opts/1                                                 1       0.003       0.002
+:lists.member/2                                                      3       0.003       0.003
+:erlang.list_to_tuple/1                                              2       0.003       0.003
+ExPng.Color.to_bytesize/1                                            2       0.003       0.003
+ExPng.Color.channels_for_color_mode/1                                2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.getStash_nif/1                                                 2       0.002       0.002
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.002       0.002
+:file.make_binary/1                                                  2       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+:erlang.iolist_to_iovec/1                                            2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.inflateInit_nif/3                                              1       0.001       0.001
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+:zlib.arg_level/1                                                    1       0.001       0.001
+:zlib.arg_eos_behavior/1                                             1       0.001       0.001
+:io.io_request/2                                                     1       0.001       0.001
+File.normalize_modes/2                                               1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite7.prof
+++ b/prof/readwrite7.prof
@@ -1,0 +1,271 @@
+Compiling 2 files (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2611671    4949.074    5382.133
+:proc_lib.init_p/5                                                 250   56333.509       4.887
+:suspend                                                          2103   55900.450       0.000
+:fprof.apply_start_stop/4                                            0    4949.074       0.011
+anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1    4949.058       0.004
+ExPng.Image.from_file/1                                              1    3160.414       0.004
+ExPng.Image.Decoding.from_raw_data/1                                 1    3158.908       0.007
+Enum.reduce/3                                                    63239    3050.970      71.049
+Enum."-reduce/3-lists^foldl/2-0-"/3                             186989    3050.572     457.965
+ExPng.Image.Decoding.filter_pass/2                                   1    2780.748       0.003
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2780.178       0.536
+ExPng.Image.Line.filter_pass/3                                     494    2779.642       2.952
+ExPng.Image.to_file/2                                                1    1788.640       0.001
+ExPng.Image.to_file/3                                                1    1788.639       0.006
+ExPng.Image.Encoding.to_raw_data/1                                   1    1765.338       0.004
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1236.972     193.346
+ExPng.Image.Encoding.build_header/1                                  1     984.176       0.002
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     984.174       0.005
+Enum.reduce_range_inc/4                                         187482     935.889     344.161
+Enum.map/2                                                           4     828.286       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     828.281       2.895
+ExPng.Chunks.ImageData.from_pixels/2                                 1     781.158       0.009
+ExPng.Image.unique_pixels/1                                          2     739.853       0.004
+Enumerable.reduce/3                                                485     647.959       1.063
+Enum.chunk_every/4                                                 241     645.368       0.248
+Stream.Reducers.chunk_every/5                                      241     645.120       0.495
+Enum."-fun.chunk_while/4-"/4                                       241     644.382       0.244
+Enum.chunk_while/4                                                 241     644.138       0.770
+Enumerable.List.reduce/3                                         60732     640.613     128.821
+List.flatten/1                                                       5     640.438       0.005
+:lists.flatten/1                                                     5     640.433       0.005
+:lists.do_flatten/2                                             315005     640.428     638.757
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     582.738     392.658
+anonymous fn/3 in Enum.chunk_while/4                             60491     511.528     127.709
+Enum.uniq/1                                                          2     476.944       0.002
+Enum.uniq_by/2                                                       2     476.942       0.002
+Enum.uniq_list/3                                                125002     476.940     345.131
+:proc_lib.init_p_do_apply/3                                        250     447.552       1.345
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     447.065       0.357
+Task.async/1                                                       250     446.708       0.328
+Task.async/3                                                       250     446.380       2.233
+Task.Supervised.reply/4                                            250     446.207       1.487
+Task.Supervised.reply/5                                            250     439.407       1.312
+Task.Supervised.start_link/4                                       250     431.464       0.671
+:proc_lib.spawn_link/3                                             250     430.793       1.556
+:erlang.spawn_link/3                                               251     423.688     422.347
+ExPng.Image.Encoding.indexable?/1                                    1     418.972       0.002
+ExPng.Image.Encoding.unique_pixel_count/1                            1     418.970       0.002
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     382.869     192.260
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     376.328       0.500
+ExPng.Image.Encoding.opaque?/1                                       1     313.503       0.002
+Task.Supervised.invoke_mfa/2                                       250     272.138       0.673
+:erlang.apply/2                                                    250     271.465       0.423
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     271.042       0.387
+ExPng.Chunks.ImageData.line_to_binary/3                            250     270.655       0.424
+Enum.take/2                                                      60744     260.819      67.210
+ExPng.Image.Line.to_pixels/4                                       250     250.718       0.250
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     250.468     187.809
+Enum.all?/2                                                          3     187.658       0.003
+Enum.all_list/2                                                  62503     187.655     125.057
+Enum.take_list/2                                                123501     187.200     186.596
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     183.689     183.224
+:erlang.send/2                                                     500     165.173     165.173
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     130.727     128.769
+anonymous fn/1 in Enum.uniq/1                                   125000     128.919     128.480
+Enum.zip/2                                                         241     128.039       0.269
+Enum.zip_list/2                                                  60491     127.769     127.243
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     127.194     126.136
+ExPng.Image.Encoding.grayscale?/1                                    1     125.849       0.002
+ExPng.Image.Encoding.black_and_white?/1                              1     125.845       0.002
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     122.739       3.207
+Enum.at/2                                                          751     110.811       0.860
+Enum.at/3                                                          751     109.951       1.622
+Enum.slice_any/3                                                   751     108.320       1.683
+Enum.drop_list/2                                                 94616     106.156     105.662
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500      81.125      81.125
+Range.new/2                                                      62494      65.066      63.782
+:lists.reverse/1                                                 60737      63.463      62.060
+ExPng.Pixel.rgb/3                                                62500      62.600      62.550
+ExPng.Pixel.opaque?/1                                            62500      62.544      62.522
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      61.465      61.043
+:garbage_collect                                                  4408      36.594      36.594
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      25.753       5.644
+ExPng.RawData.to_file/3                                              1      23.295       0.026
+:zlib.dequeue_all_chunks/2                                           2      22.880       0.002
+:zlib.dequeue_all_chunks_1/3                                        39      22.878       0.268
+ExPng.Chunks.ImageData.to_bytes/2                                    1      22.708       0.021
+ExPng.Chunks.ImageData.deflate/2                                     1      22.568       0.014
+:zlib.deflate/3                                                      1      22.280       0.008
+Enum.reduce/2                                                      274      17.645       0.334
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      17.311       6.228
+ExPng.Image.Line.build_pad_for_filter/1                            244      11.075       0.833
+:erlang.monitor/2                                                  255       9.564       0.404
+ExPng.Utilities.reduce_to_binary/1                                  44       9.391       0.208
+:zlib.dequeue_next_chunk/2                                          39       8.527       0.063
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               250       8.478       5.878
+:zlib."-fun.deflate_nif/4-"/4                                       27       7.959       0.047
+:zlib.deflate_nif/4                                                 27       7.912       7.909
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       5.795       5.365
+Enumerable.Function.reduce/3                                       244       4.784       0.279
+anonymous fn/4 in Stream.unfold/2                                  244       4.505       0.285
+Stream.do_unfold/4                                                 976       4.220       2.732
+Task.Supervised.initial_call/1                                     250       4.064       1.139
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.564       3.521
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.425       2.353
+Task.get_owner/1                                                   250       2.309       0.728
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       2.037       1.945
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       1.991       0.336
+:proc_lib.get_my_name/0                                            250       1.981       0.765
+Process.put/2                                                      500       1.916       1.311
+Task.Supervised.get_initial_call/1                                 250       1.912       1.202
+:erlang.put/2                                                     1000       1.876       1.876
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.868       1.711
+Task.await/1                                                       250       1.655       0.330
+Enum.with_index/1                                                    3       1.604       0.003
+Enum.with_index/2                                                    3       1.601       0.006
+Enum.do_with_index/2                                               753       1.592       1.588
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.589       1.586
+Process.info/2                                                     250       1.581       0.735
+ExPng.RawData.from_file/1                                            1       1.502       0.006
+:lists.reverse/2                                                   734       1.500       0.968
+Enumerable.impl_for!/1                                             485       1.498       1.005
+Task.await/2                                                       250       1.325       0.671
+Task.Supervised.put_callers/1                                      250       1.249       0.346
+:erlang.process_info/2                                             500       1.241       1.241
+:proc_lib.proc_info/2                                              250       1.216       0.821
+ExPng.Image.Decoding.build_lines/1                                   1       1.059       0.003
+ExPng.RawData.from_chunks/2                                          1       1.052       0.005
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.047       0.778
+Enum.reverse/1                                                     270       0.992       0.570
+ExPng.Chunks.ImageData.merge/1                                       1       0.861       0.005
+Enum.drop/2                                                        245       0.803       0.281
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.762       0.757
+anonymous fn/2 in Enum.take/2                                      732       0.745       0.743
+anonymous fn/1 in Stream.cycle/1                                   732       0.741       0.740
+:erlang.fun_info/2                                                 500       0.710       0.710
+ExPng.Chunks.ImageData.inflate/1                                     1       0.692       0.008
+:erlang.demonitor/2                                                254       0.664       0.348
+:zlib.inflate/2                                                      1       0.655       0.001
+:zlib.inflate/3                                                      1       0.654       0.007
+:proc_lib.trans_init/3                                             250       0.611       0.611
+Stream.cycle/1                                                     244       0.544       0.297
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.519       0.519
+File.write/2                                                         1       0.508       0.003
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.505       0.014
+File.write/3                                                         1       0.505       0.009
+Enumerable.impl_for/1                                              485       0.493       0.492
+:file.write_file/3                                                   1       0.492       0.011
+:zlib.inflate_nif/4                                                 12       0.491       0.491
+:file.do_write_file/3                                                1       0.478       0.011
+:proc_lib.get_ancestors/0                                          250       0.376       0.376
+Task.get_callers/1                                                 250       0.362       0.362
+:file.call/2                                                         2       0.339       0.011
+:gen_server.call/3                                                   2       0.323       0.010
+:erts_internal.flush_monitor_messages/3                            250       0.316       0.316
+:gen.call/4                                                          2       0.313       0.005
+:erlang.crc32/1                                                     14       0.309       0.153
+:gen.do_for_proc/2                                                   2       0.308       0.012
+ExPng.RawData.parse_chunks/2                                        11       0.307       0.046
+anonymous fn/4 in :gen.call/4                                        2       0.291       0.003
+:gen.do_call/4                                                       2       0.288       0.038
+:file.open/2                                                         1       0.265       0.013
+ExPng.Image.Line.new/2                                             250       0.253       0.253
+Stream.unfold/2                                                    244       0.247       0.247
+:erlang.max/2                                                      241       0.243       0.243
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.243       0.243
+ExPng.RawData.validate_crc/3                                        11       0.230       0.026
+:file.write/2                                                        1       0.118       0.007
+File.read/1                                                          1       0.116       0.003
+:file.read_file/1                                                    1       0.111       0.003
+:io.request/2                                                        1       0.109       0.005
+:file.check_and_call/2                                               1       0.106       0.003
+:io.execute_request/2                                                1       0.102       0.011
+:file.close/1                                                        1       0.084       0.005
+:file.file_request/2                                                 1       0.079       0.008
+ExPng.RawData.find_end/1                                             1       0.064       0.003
+Enum.reject/2                                                        2       0.063       0.002
+ExPng.RawData.find_image_data/1                                      1       0.062       0.002
+Enum.reject_list/2                                                  17       0.061       0.046
+ExPng.RawData.find_palette/2                                         1       0.060       0.003
+Enum.split_with/2                                                    1       0.060       0.004
+ExPng.RawData.find_chunk/2                                           2       0.055       0.002
+:zlib.append_iolist/2                                               41       0.054       0.054
+Enum.find/2                                                          2       0.053       0.002
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.052       0.022
+Enum.find/3                                                          2       0.051       0.003
+:zlib.deflateInit/2                                                  1       0.048       0.002
+Enum.find_list/3                                                    16       0.048       0.031
+:zlib.deflateInit/6                                                  1       0.046       0.007
+:zlib.deflateEnd/1                                                   1       0.045       0.002
+:zlib.deflateEnd_nif/1                                               1       0.043       0.043
+:zlib.deflateInit_nif/6                                              1       0.034       0.034
+anonymous fn/3 in Enum.split_with/2                                 10       0.030       0.020
+ExPng.Chunks.from_type/2                                            11       0.029       0.013
+ExPng.RawData.parse_ihdr/1                                           1       0.021       0.008
+ExPng.Chunks.Header.to_bytes/1                                       1       0.020       0.002
+ExPng.Chunks.Header.to_bytes/2                                       1       0.018       0.012
+:zlib.enqueue_input/2                                                2       0.017       0.005
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.017       0.016
+:erlang.send/3                                                       2       0.014       0.014
+:zlib.inflateEnd/1                                                   1       0.013       0.002
+:zlib.open/0                                                         2       0.012       0.002
+:file.check_args/1                                                   6       0.012       0.012
+:zlib.inflateEnd_nif/1                                               1       0.011       0.011
+Keyword.get/3                                                        1       0.011       0.003
+ExPng.Chunks.End.to_bytes/1                                          1       0.011       0.002
+:zlib.open_nif/0                                                     2       0.010       0.010
+:zlib.enqueue_input_1/2                                              2       0.010       0.004
+:erlang.binary_to_atom/2                                            10       0.010       0.010
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.010       0.010
+:zlib.inflateInit/1                                                  1       0.009       0.001
+:zlib.exception_on_need_dict/2                                       1       0.009       0.004
+ExPng.Color.line_bytesize/1                                          1       0.009       0.002
+ExPng.Chunks.End.to_bytes/2                                          1       0.009       0.007
+:zlib.inflateInit/2                                                  1       0.008       0.002
+:lists.keyfind/3                                                     1       0.008       0.004
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.008       0.008
+:zlib.restore_progress/2                                             2       0.007       0.005
+:zlib.close/1                                                        2       0.007       0.005
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.007       0.007
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Color.pixel_bitsize/2                                          2       0.007       0.005
+ExPng.Color.line_bytesize/3                                          1       0.007       0.002
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateInit/3                                                  1       0.006       0.003
+:zlib.enqueue_nif/2                                                  2       0.006       0.006
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Chunks.Header.new/2                                            1       0.006       0.004
+:lists.member/2                                                      3       0.005       0.005
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.005       0.005
+:erlang.whereis/1                                                    2       0.005       0.005
+:erlang.list_to_tuple/1                                              2       0.005       0.005
+:zlib.deflate_opts/1                                                 1       0.004       0.003
+IO.chardata_to_string/1                                              2       0.004       0.004
+:zlib.inflate_opts/0                                                 1       0.003       0.002
+:file.make_binary/1                                                  2       0.003       0.003
+:file.file_name/1                                                    2       0.003       0.003
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.getStash_nif/1                                                 2       0.002       0.002
+:zlib.close_nif/1                                                    2       0.002       0.002
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:erlang.iolist_to_iovec/1                                            2       0.002       0.002
+File.normalize_modes/2                                               1       0.002       0.002
+ExPng.Color.to_bytesize/1                                            2       0.002       0.002
+ExPng.Color.channels_for_color_mode/1                                2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.inflateInit_nif/3                                              1       0.001       0.001
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+:zlib.arg_level/1                                                    1       0.001       0.001
+:zlib.arg_eos_behavior/1                                             1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite8.prof
+++ b/prof/readwrite8.prof
@@ -1,0 +1,270 @@
+Compiling 1 file (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2312077    4363.232    5327.330
+:proc_lib.init_p/5                                                 250   31603.146       9.090
+:suspend                                                          1828   30639.048       0.000
+:fprof.apply_start_stop/4                                            0    4363.232       0.009
+anonymous fn/0 in :elixir_compiler_1.__FILE__/1                      1    4363.219       0.004
+Enum.reduce/3                                                    63239    3696.833      70.307
+Enum."-reduce/3-lists^foldl/2-0-"/3                             186989    3695.458     932.488
+ExPng.Image.from_file/1                                              1    3135.038       0.005
+ExPng.Image.Decoding.from_raw_data/1                                 1    3133.575       0.006
+ExPng.Image.Decoding.filter_pass/2                                   1    2752.805       0.003
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2752.252       0.533
+ExPng.Image.Line.filter_pass/3                                     494    2751.719       2.868
+ExPng.Image.to_file/2                                                1    1228.177       0.001
+ExPng.Image.to_file/3                                                1    1228.176       0.006
+ExPng.Image.Encoding.to_raw_data/1                                   1    1218.344       0.006
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1218.063     191.071
+:proc_lib.init_p_do_apply/3                                        250    1041.114       2.496
+Task.Supervised.reply/4                                            250    1038.618       4.336
+Task.Supervised.reply/5                                            250    1017.216       3.841
+Task.Supervised.invoke_mfa/2                                       250     950.641       2.229
+:erlang.apply/2                                                    250     948.412       1.503
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     946.909       1.337
+ExPng.Chunks.ImageData.line_to_binary/3                            250     945.572       1.535
+Enum.reduce_range_inc/4                                         187482     919.085     340.394
+Enum.map/2                                                           4     849.927       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     849.922       2.737
+ExPng.Chunks.ImageData.from_pixels/2                                 1     803.296       0.009
+ExPng.Image.unique_pixels/1                                          2     702.726       0.006
+Enumerable.reduce/3                                                485     643.787       1.041
+Enum.chunk_every/4                                                 241     641.366       0.243
+Stream.Reducers.chunk_every/5                                      241     641.121       0.485
+Enum."-fun.chunk_while/4-"/4                                       241     640.384       0.242
+Enum.chunk_while/4                                                 241     640.142       0.774
+Enumerable.List.reduce/3                                         60732     636.572     128.110
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     570.821     383.115
+anonymous fn/3 in Enum.chunk_while/4                             60491     508.240     127.186
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     466.199       0.338
+Task.async/1                                                       250     465.861       0.325
+Task.async/3                                                       250     465.536       2.197
+Enum.uniq/1                                                          2     447.518       0.002
+Enum.uniq_by/2                                                       2     447.516       0.002
+Enum.uniq_list/3                                                125002     447.514     316.792
+ExPng.Image.Encoding.build_header/1                                  1     415.042       0.003
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     415.039       0.007
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     380.261     191.034
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     378.967       0.500
+Task.Supervised.start_link/4                                       250     377.981       0.716
+:proc_lib.spawn_link/3                                             250     374.091       1.419
+:erlang.spawn_link/3                                               250     370.430     370.430
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500     273.847     273.847
+Enum.take/2                                                      60744     259.947      66.284
+List.flatten/1                                                       2     255.202       0.003
+:lists.flatten/1                                                     2     255.199       0.002
+:lists.do_flatten/2                                             126002     255.197     254.973
+ExPng.Image.Line.to_pixels/4                                       250     252.635       0.250
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     252.385     189.376
+Enum.take_list/2                                                123501     187.712     187.124
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     182.657     182.313
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     134.180       3.385
+anonymous fn/1 in Enum.uniq/1                                   125000     129.845     128.688
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     127.858     126.688
+Enum.zip/2                                                         241     127.097       0.275
+Enum.zip_list/2                                                  60491     126.822     126.483
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     126.231     125.348
+Enum.at/2                                                          751     121.719       0.906
+Enum.at/3                                                          751     120.813       1.700
+Enum.slice_any/3                                                   751     119.105       1.784
+Enum.drop_list/2                                                 94616     116.713     116.478
+Task.get_owner/1                                                   250      84.232       0.729
+Process.info/2                                                     250      83.503       1.090
+Range.new/2                                                      62494      64.151      63.271
+:lists.reverse/1                                                 60737      63.330      61.894
+:erlang.send/2                                                     500      63.134      63.122
+ExPng.Pixel.rgb/3                                                62500      62.920      62.798
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      61.095      60.795
+Enum.all?/2                                                          3      36.705       0.004
+Enum.all_list/2                                                   7384      36.701      28.472
+ExPng.Image.Encoding.opaque?/1                                       1      36.696       0.001
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      22.109       5.031
+:garbage_collect                                                  4339      19.398      19.398
+Enum.reduce/2                                                      274      16.249       0.313
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      15.936       6.113
+Task.Supervised.initial_call/1                                     250      12.392       2.980
+ExPng.Image.Line.build_pad_for_filter/1                            244      10.751       0.807
+ExPng.RawData.to_file/3                                              1       9.826       0.032
+:zlib.dequeue_all_chunks/2                                           2       9.432       0.003
+:zlib.dequeue_all_chunks_1/3                                        39       9.429       0.329
+ExPng.Chunks.ImageData.to_bytes/2                                    1       9.330       0.033
+ExPng.Chunks.ImageData.deflate/2                                     1       9.188       0.016
+ExPng.Utilities.reduce_to_binary/1                                  44       9.012       0.226
+:zlib.deflate/3                                                      1       8.878       0.012
+:zlib.dequeue_next_chunk/2                                          39       8.473       0.089
+ExPng.Pixel.opaque?/1                                             7381       8.200       8.182
+:zlib."-fun.deflate_nif/4-"/4                                       27       7.878       0.073
+:zlib.deflate_nif/4                                                 27       7.805       7.795
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               250       7.574       2.314
+Process.put/2                                                      500       6.717       4.607
+Task.Supervised.get_initial_call/1                                 250       6.015       3.906
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       4.832       4.735
+:erlang.put/2                                                     1000       4.710       4.710
+Task.Supervised.put_callers/1                                      250       4.674       1.354
+Enumerable.Function.reduce/3                                       244       4.674       0.273
+anonymous fn/4 in Stream.unfold/2                                  244       4.401       0.272
+Stream.do_unfold/4                                                 976       4.129       2.641
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.022       3.014
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.498       2.457
+:erlang.fun_info/2                                                 500       2.109       2.109
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       2.017       0.332
+:proc_lib.get_my_name/0                                            250       1.895       0.743
+:erlang.process_info/2                                             500       1.731       1.731
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.712       1.689
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.700       1.695
+Task.await/1                                                       250       1.685       0.348
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.613       1.589
+Enum.with_index/1                                                    3       1.605       0.003
+Enum.with_index/2                                                    3       1.602       0.006
+Enum.do_with_index/2                                               753       1.593       1.591
+:lists.reverse/2                                                   733       1.495       0.967
+Enumerable.impl_for!/1                                             485       1.489       1.001
+ExPng.RawData.from_file/1                                            1       1.458       0.006
+Task.await/2                                                       250       1.336       0.677
+:proc_lib.trans_init/3                                             250       1.227       1.227
+:proc_lib.proc_info/2                                              250       1.152       0.745
+ExPng.Image.Decoding.build_lines/1                                   1       1.031       0.002
+Enum.reverse/1                                                     270       1.022       0.554
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.021       0.759
+ExPng.RawData.from_chunks/2                                          1       0.972       0.005
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.788       0.787
+Enum.drop/2                                                        245       0.784       0.271
+ExPng.Chunks.ImageData.merge/1                                       1       0.783       0.005
+anonymous fn/1 in Stream.cycle/1                                   732       0.743       0.743
+anonymous fn/2 in Enum.take/2                                      732       0.742       0.741
+:erlang.demonitor/2                                                254       0.671       0.345
+ExPng.Chunks.ImageData.inflate/1                                     1       0.643       0.006
+:zlib.inflate/2                                                      1       0.614       0.001
+:zlib.inflate/3                                                      1       0.613       0.005
+Stream.cycle/1                                                     244       0.526       0.276
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.516       0.515
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.506       0.013
+:zlib.inflate_nif/4                                                 12       0.493       0.493
+Enumerable.impl_for/1                                              485       0.486       0.486
+File.write/2                                                         1       0.440       0.003
+File.write/3                                                         1       0.437       0.008
+:file.write_file/3                                                   1       0.426       0.008
+:file.do_write_file/3                                                1       0.415       0.006
+:erlang.monitor/2                                                  254       0.391       0.391
+ExPng.RawData.parse_chunks/2                                        11       0.348       0.043
+:proc_lib.get_ancestors/0                                          250       0.347       0.347
+Task.get_callers/1                                                 250       0.342       0.342
+:erlang.crc32/1                                                     14       0.336       0.123
+:erts_internal.flush_monitor_messages/3                            251       0.326       0.326
+:file.call/2                                                         2       0.288       0.012
+ExPng.RawData.validate_crc/3                                        11       0.276       0.024
+:gen_server.call/3                                                   2       0.273       0.007
+:gen.call/4                                                          2       0.266       0.005
+:gen.do_for_proc/2                                                   2       0.261       0.009
+:erlang.max/2                                                      241       0.251       0.243
+ExPng.Image.Line.new/2                                             250       0.250       0.250
+Stream.unfold/2                                                    244       0.249       0.248
+anonymous fn/4 in :gen.call/4                                        2       0.248       0.004
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.247       0.245
+:gen.do_call/4                                                       2       0.244       0.031
+:file.open/2                                                         1       0.217       0.012
+File.read/1                                                          1       0.112       0.004
+:file.read_file/1                                                    1       0.106       0.005
+:file.write/2                                                        1       0.100       0.006
+:file.check_and_call/2                                               1       0.100       0.003
+:io.request/2                                                        1       0.093       0.004
+:file.close/1                                                        1       0.092       0.004
+:file.file_request/2                                                 1       0.088       0.010
+:io.execute_request/2                                                1       0.087       0.008
+:zlib.append_iolist/2                                               41       0.069       0.069
+:zlib.deflateInit/2                                                  1       0.066       0.002
+:zlib.deflateInit/6                                                  1       0.064       0.015
+ExPng.RawData.find_end/1                                             1       0.063       0.003
+Enum.reject/2                                                        2       0.063       0.002
+ExPng.RawData.find_image_data/1                                      1       0.061       0.002
+Enum.reject_list/2                                                  17       0.061       0.046
+ExPng.RawData.find_palette/2                                         1       0.060       0.003
+Enum.split_with/2                                                    1       0.059       0.004
+ExPng.RawData.find_chunk/2                                           2       0.054       0.002
+Enum.find/2                                                          2       0.052       0.002
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.051       0.021
+Enum.find/3                                                          2       0.050       0.002
+Enum.find_list/3                                                    16       0.048       0.031
+:zlib.deflateInit_nif/6                                              1       0.043       0.034
+ExPng.Chunks.from_type/2                                            11       0.030       0.012
+anonymous fn/3 in Enum.split_with/2                                 10       0.030       0.020
+:zlib.enqueue_input/2                                                2       0.020       0.006
+ExPng.RawData.parse_ihdr/1                                           1       0.020       0.005
+Keyword.get/3                                                        1       0.019       0.004
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.017       0.016
+:zlib.open/0                                                         2       0.016       0.003
+ExPng.Chunks.Header.to_bytes/1                                       1       0.016       0.002
+:lists.keyfind/3                                                     1       0.015       0.006
+:erlang.send/3                                                       2       0.014       0.014
+ExPng.Chunks.Header.to_bytes/2                                       1       0.014       0.011
+:zlib.open_nif/0                                                     2       0.013       0.013
+:zlib.enqueue_input_1/2                                              2       0.011       0.005
+:file.check_args/1                                                   6       0.011       0.011
+:erlang.binary_to_atom/2                                            10       0.011       0.011
+:zlib.inflateEnd/1                                                   1       0.010       0.001
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.010       0.010
+:zlib.inflateInit/1                                                  1       0.009       0.002
+:zlib.inflateEnd_nif/1                                               1       0.009       0.009
+:zlib.deflateEnd/1                                                   1       0.009       0.003
+:zlib.restore_progress/2                                             2       0.008       0.005
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.008       0.008
+ExPng.Color.line_bytesize/1                                          1       0.008       0.002
+ExPng.Chunks.Header.new/2                                            1       0.008       0.006
+ExPng.Chunks.End.to_bytes/1                                          1       0.008       0.002
+:zlib.inflateInit/2                                                  1       0.007       0.001
+:zlib.exception_on_need_dict/2                                       1       0.007       0.003
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.007       0.007
+ExPng.Image.Encoding.grayscale?/1                                    1       0.007       0.001
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateInit/3                                                  1       0.006       0.003
+:zlib.enqueue_nif/2                                                  2       0.006       0.006
+:zlib.deflateEnd_nif/1                                               1       0.006       0.006
+:zlib.close/1                                                        2       0.006       0.003
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Color.pixel_bitsize/2                                          2       0.006       0.004
+ExPng.Color.line_bytesize/3                                          1       0.006       0.002
+ExPng.Chunks.End.to_bytes/2                                          1       0.006       0.005
+:zlib.deflate_opts/1                                                 1       0.005       0.003
+ExPng.Image.Encoding.black_and_white?/1                              1       0.005       0.001
+:lists.member/2                                                      3       0.004       0.004
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.004       0.004
+:erlang.whereis/1                                                    2       0.004       0.004
+:zlib.inflate_opts/0                                                 1       0.003       0.002
+:zlib.getStash_nif/1                                                 2       0.003       0.003
+:zlib.close_nif/1                                                    2       0.003       0.003
+:zlib.arg_flush/1                                                    2       0.003       0.003
+:erlang.list_to_tuple/1                                              2       0.003       0.003
+:erlang.iolist_to_iovec/1                                            2       0.003       0.003
+IO.chardata_to_string/1                                              2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.arg_strategy/1                                                 1       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:file.make_binary/1                                                  2       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+File.normalize_modes/2                                               1       0.002       0.002
+ExPng.Color.to_bytesize/1                                            2       0.002       0.002
+ExPng.Color.channels_for_color_mode/1                                2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.inflateInit_nif/3                                              1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+:zlib.arg_level/1                                                    1       0.001       0.001
+:zlib.arg_eos_behavior/1                                             1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Image.Encoding.indexable?/1                                    1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/prof/readwrite9.prof
+++ b/prof/readwrite9.prof
@@ -1,0 +1,269 @@
+Compiling 1 file (.ex)
+Warmup...
+Reading trace data...
+End of trace!
+Processing data...
+Creating output...
+Done!
+
+                                                                   CNT    ACC (ms)    OWN (ms)
+Total                                                          2187916    4256.359    4948.178
+:proc_lib.init_p/5                                                 250   35211.513       5.684
+:suspend                                                          1995   34519.694       0.000
+:fprof.apply_start_stop/4                                            0    4256.359       0.008
+anonymous fn/0 in :elixir_compiler_2.__FILE__/1                      1    4256.350       0.003
+Enum.reduce/3                                                    63241    3429.319      70.859
+Enum."-reduce/3-lists^foldl/2-0-"/3                             187491    3428.407     683.340
+ExPng.Image.from_file/1                                              1    3158.712       0.003
+ExPng.Image.Decoding.from_raw_data/1                                 1    3156.945       0.006
+ExPng.Image.Decoding.filter_pass/2                                   1    2761.971       0.003
+anonymous fn/3 in ExPng.Image.Decoding.filter_pass/2               250    2761.411       0.531
+ExPng.Image.Line.filter_pass/3                                     494    2760.880       2.914
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                 60250    1231.142     193.015
+ExPng.Image.to_file/2                                                1    1097.635       0.001
+ExPng.Image.to_file/3                                                1    1097.634       0.004
+ExPng.Image.Encoding.to_raw_data/1                                   1    1089.226       0.004
+Enum.reduce_range_inc/4                                         187482     926.563     340.678
+Enum.map/2                                                           4     887.032       0.005
+Enum."-map/2-lists^map/1-0-"/2                                     756     887.027       3.079
+ExPng.Chunks.ImageData.from_pixels/2                                 1     815.825       0.007
+:proc_lib.init_p_do_apply/3                                        250     752.107       1.806
+Task.Supervised.reply/4                                            250     750.301       2.874
+Task.Supervised.reply/5                                            250     735.855       2.518
+Enumerable.reduce/3                                                485     647.267       1.044
+Enum.chunk_every/4                                                 241     645.250       0.247
+Stream.Reducers.chunk_every/5                                      241     644.985       0.488
+Enum."-fun.chunk_while/4-"/4                                       241     644.253       0.243
+Enum.chunk_while/4                                                 241     644.010       0.784
+Enumerable.List.reduce/3                                         60732     639.987     129.219
+Task.Supervised.invoke_mfa/2                                       250     594.272       1.449
+:erlang.apply/2                                                    250     592.823       0.890
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     591.933       0.871
+ExPng.Chunks.ImageData.line_to_binary/3                            250     591.062       0.982
+anonymous fn/6 in ExPng.Image.Line.filter_pass/3                180750     577.633     387.999
+ExPng.Image.unique_pixels/1                                          2     569.052       0.006
+anonymous fn/3 in Enum.chunk_while/4                             60491     510.554     127.657
+Enum.uniq/1                                                          2     491.769       0.003
+Enum.uniq_by/2                                                       2     491.766       0.004
+Enum.uniq_list/3                                                125002     491.762     355.349
+anonymous fn/3 in ExPng.Chunks.ImageData.from_pixels/2             250     488.039       0.405
+Task.async/1                                                       250     487.634       0.831
+Task.async/3                                                       250     430.116       2.522
+Task.Supervised.start_link/4                                       250     423.541       0.769
+:proc_lib.spawn_link/3                                             250     422.772       1.667
+:erlang.spawn_link/3                                               250     418.523     418.523
+anonymous fn/2 in ExPng.Image.Decoding.from_raw_data/1             250     393.163       0.507
+anonymous fn/5 in Stream.Reducers.chunk_every/5                  60491     382.096     192.043
+ExPng.Image.Encoding.build_header/1                                  1     273.397       0.002
+ExPng.Image.Encoding.bit_depth_and_color_mode/1                      1     273.395       0.006
+ExPng.Image.Line.to_pixels/4                                       250     266.454       0.254
+ExPng.Image.Line."-to_pixels/4-lc$^5/1-9-"/1                     62750     266.199     189.815
+Enum.take/2                                                      60744     261.189      67.031
+Enum.take_list/2                                                123501     188.272     187.630
+ExPng.Image.Line.calculate_paeth_delta/3                        180750     183.249     182.803
+anonymous fn/3 in ExPng.Chunks.ImageData.line_to_binary/3        62500     174.687     174.687
+:erlang.send/2                                                     500     139.550     139.538
+anonymous fn/1 in Enum.uniq/1                                   125000     132.668     129.721
+ExPng.Image.Line."-filter_pass/3-lc$^10/1-3-"/2                  60491     129.960     127.997
+Enum.zip/2                                                         241     128.546       0.277
+Enum.zip_list/2                                                  60491     128.269     127.879
+ExPng.Image.Line."-filter_pass/3-lc$^11/1-4-"/2                  60491     126.452     125.439
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                   750     120.395       3.170
+Enum.at/2                                                          751     108.817       0.831
+Enum.at/3                                                          751     107.986       1.601
+Enum.slice_any/3                                                   751     106.385       1.644
+Enum.drop_list/2                                                 94616     104.164     103.975
+:garbage_collect                                                  4513      78.112      78.112
+anonymous fn/2 in ExPng.Image.unique_pixels/1                      500      76.117       1.821
+ExPng.Pixel.rgb/3                                                62500      69.753      63.039
+Range.new/2                                                      62494      64.344      63.389
+:lists.reverse/1                                                 60737      63.918      62.004
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                 60250      61.508      61.088
+:erlang.++/2                                                       500      29.163      28.468
+Enum.all?/2                                                          3      22.165       0.003
+Enum.all_list/2                                                   7384      22.162      14.771
+ExPng.Image.Encoding.opaque?/1                                       1      22.158       0.001
+anonymous fn/3 in ExPng.Image.Line.filter_pass/3                  1494      20.327       4.658
+Enum.reduce/2                                                      274      11.667       0.311
+Enum."-reduce/2-lists^foldl/2-0-"/3                               2506      11.356       5.741
+ExPng.Image.Line.build_pad_for_filter/1                            244      10.872       0.811
+:zlib.dequeue_all_chunks/2                                           2       8.521       0.002
+:zlib.dequeue_all_chunks_1/3                                        39       8.519       0.264
+Task.Supervised.initial_call/1                                     250       8.465       2.021
+ExPng.RawData.to_file/3                                              1       8.404       0.015
+ExPng.Chunks.ImageData.to_bytes/2                                    1       7.866       0.012
+ExPng.Chunks.ImageData.deflate/2                                     1       7.781       0.011
+:zlib.deflate/3                                                      1       7.586       0.009
+ExPng.Pixel.opaque?/1                                             7381       7.385       7.383
+:zlib.dequeue_next_chunk/2                                          39       6.190       0.061
+:zlib."-fun.deflate_nif/4-"/4                                       27       5.622       0.056
+:zlib.deflate_nif/4                                                 27       5.566       5.563
+ExPng.Utilities.reduce_to_binary/1                                  44       5.126       0.164
+Enumerable.Function.reduce/3                                       244       4.746       0.277
+anonymous fn/4 in ExPng.Image.Line.filter_pass/3                  4482       4.584       4.554
+Process.put/2                                                      500       4.505       3.103
+anonymous fn/4 in Stream.unfold/2                                  244       4.469       0.279
+Stream.do_unfold/4                                                 976       4.190       2.693
+Task.Supervised.get_initial_call/1                                 250       4.120       2.660
+anonymous fn/2 in ExPng.Utilities.reduce_to_binary/1               250       3.556       2.356
+:erlang.put/2                                                     1000       3.187       3.187
+ExPng.Image.Line."-filter_pass/3-lc$^0/1-0-"/2                    1506       3.179       3.151
+Task.Supervised.put_callers/1                                      250       3.107       0.926
+Task.get_owner/1                                                   250       2.745       0.796
+anonymous fn/1 in ExPng.Chunks.ImageData.from_pixels/2             250       2.744       0.463
+anonymous fn/5 in ExPng.Image.Line.filter_pass/3                  2250       2.383       2.331
+Task.await/1                                                       250       2.281       0.455
+:proc_lib.get_my_name/0                                            250       2.196       0.867
+Process.info/2                                                     250       1.949       0.798
+Task.await/2                                                       250       1.826       0.874
+ExPng.RawData.from_file/1                                            1       1.764       0.005
+Enum.with_index/1                                                    3       1.664       0.003
+Enum.with_index/2                                                    3       1.661       0.006
+Enum.do_with_index/2                                               753       1.652       1.557
+ExPng.Image.Line."-filter_pass/3-lc$^5/1-1-"/2                     753       1.648       1.635
+ExPng.Image.Line."-filter_pass/3-lc$^6/1-2-"/2                     753       1.629       1.608
+:erlang.process_info/2                                             500       1.585       1.574
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                  1494       1.544       1.519
+Enumerable.impl_for!/1                                             485       1.490       1.000
+:erlang.fun_info/2                                                 500       1.460       1.460
+:lists.reverse/2                                                   733       1.373       0.952
+ExPng.RawData.from_chunks/2                                          1       1.331       0.005
+:proc_lib.proc_info/2                                              250       1.329       0.895
+ExPng.Chunks.ImageData.merge/1                                       1       1.142       0.005
+ExPng.Image.Decoding.build_lines/1                                   1       1.033       0.003
+ExPng.Image.Decoding."-build_lines/1-lc$^0/1-0-"/2                 251       1.023       0.760
+ExPng.Chunks.ImageData.inflate/1                                     1       1.006       0.006
+:zlib.inflate/2                                                      1       0.986       0.001
+:zlib.inflate/3                                                      1       0.985       0.005
+:erlang.demonitor/2                                                254       0.886       0.486
+Enum.reverse/1                                                     270       0.879       0.557
+Enum.drop/2                                                        245       0.823       0.279
+:proc_lib.trans_init/3                                             250       0.822       0.822
+anonymous fn/2 in ExPng.Image.Line.filter_pass/3                   750       0.773       0.756
+anonymous fn/2 in Enum.take/2                                      732       0.744       0.743
+anonymous fn/1 in Stream.cycle/1                                   732       0.740       0.740
+Stream.cycle/1                                                     244       0.534       0.282
+anonymous fn/2 in ExPng.Image.Line.build_pad_for_filter/1          488       0.514       0.513
+:zlib."-fun.inflate_nif/4-"/4                                       12       0.507       0.012
+File.write/2                                                         1       0.496       0.001
+:zlib.inflate_nif/4                                                 12       0.495       0.495
+File.write/3                                                         1       0.495       0.005
+Enumerable.impl_for/1                                              485       0.490       0.490
+:file.write_file/3                                                   1       0.486       0.005
+:file.do_write_file/3                                                1       0.479       0.005
+:erlang.monitor/2                                                  254       0.452       0.452
+:erts_internal.flush_monitor_messages/3                            251       0.400       0.388
+:proc_lib.get_ancestors/0                                          250       0.386       0.386
+Task.get_callers/1                                                 250       0.377       0.377
+:file.call/2                                                         2       0.373       0.008
+:gen_server.call/3                                                   2       0.363       0.006
+:gen.call/4                                                          2       0.357       0.003
+:gen.do_for_proc/2                                                   2       0.354       0.006
+anonymous fn/4 in :gen.call/4                                        2       0.346       0.002
+:gen.do_call/4                                                       2       0.344       0.018
+ExPng.RawData.parse_chunks/2                                        11       0.263       0.042
+Stream.unfold/2                                                    244       0.252       0.252
+:file.open/2                                                         1       0.250       0.008
+ExPng.Image.Line.new/2                                             250       0.250       0.250
+:erlang.max/2                                                      241       0.244       0.243
+anonymous fn/3 in Stream.Reducers.chunk_every/5                    241       0.244       0.243
+ExPng.RawData.validate_crc/3                                        11       0.192       0.023
+File.read/1                                                          1       0.152       0.002
+:file.read_file/1                                                    1       0.149       0.002
+:file.check_and_call/2                                               1       0.146       0.002
+:file.write/2                                                        1       0.123       0.004
+:io.request/2                                                        1       0.118       0.004
+:io.execute_request/2                                                1       0.112       0.010
+:erlang.crc32/1                                                     14       0.108       0.093
+:file.close/1                                                        1       0.101       0.003
+:file.file_request/2                                                 1       0.098       0.008
+ExPng.RawData.find_end/1                                             1       0.063       0.003
+Enum.reject/2                                                        2       0.063       0.002
+ExPng.RawData.find_image_data/1                                      1       0.061       0.002
+Enum.reject_list/2                                                  17       0.061       0.046
+ExPng.RawData.find_palette/2                                         1       0.060       0.003
+Enum.split_with/2                                                    1       0.059       0.004
+ExPng.RawData.find_chunk/2                                           2       0.054       0.002
+Enum.find/2                                                          2       0.052       0.002
+Enum."-split_with/2-lists^foldl/2-0-"/3                             11       0.051       0.021
+:zlib.append_iolist/2                                               41       0.050       0.050
+Enum.find/3                                                          2       0.050       0.002
+Enum.find_list/3                                                    16       0.048       0.031
+:zlib.deflateInit/2                                                  1       0.043       0.002
+:zlib.deflateInit/6                                                  1       0.041       0.011
+anonymous fn/3 in Enum.split_with/2                                 10       0.030       0.020
+ExPng.Chunks.from_type/2                                            11       0.026       0.011
+:zlib.deflateInit_nif/6                                              1       0.024       0.024
+anonymous fn/2 in ExPng.RawData.find_chunk/2                        15       0.017       0.016
+:zlib.enqueue_input/2                                                2       0.016       0.005
+Keyword.get/3                                                        1       0.015       0.004
+:zlib.open/0                                                         2       0.014       0.003
+ExPng.RawData.parse_ihdr/1                                           1       0.013       0.003
+ExPng.Chunks.Header.to_bytes/1                                       1       0.012       0.001
+:zlib.open_nif/0                                                     2       0.011       0.011
+:lists.keyfind/3                                                     1       0.011       0.006
+ExPng.Chunks.Header.to_bytes/2                                       1       0.011       0.008
+:file.check_args/1                                                   6       0.010       0.010
+:erlang.binary_to_atom/2                                            10       0.010       0.010
+anonymous fn/1 in ExPng.RawData.find_image_data/1                   10       0.010       0.010
+:zlib.restore_progress/2                                             2       0.009       0.006
+:zlib.inflateInit/1                                                  1       0.008       0.001
+:zlib.enqueue_input_1/2                                              2       0.008       0.004
+anonymous fn/2 in ExPng.RawData.find_end/1                           8       0.008       0.008
+:zlib.inflateInit/2                                                  1       0.007       0.001
+anonymous fn/2 in ExPng.RawData.find_palette/2                       7       0.007       0.007
+ExPng.Color.pixel_bytesize/1                                         1       0.007       0.001
+ExPng.Color.line_bytesize/1                                          1       0.007       0.001
+ExPng.Chunks.Ancillary.new/2                                         7       0.007       0.007
+:zlib.inflateInit/3                                                  1       0.006       0.003
+:zlib.exception_on_need_dict/2                                       1       0.006       0.002
+:zlib.deflateEnd/1                                                   1       0.006       0.001
+ExPng.Color.pixel_bytesize/2                                         1       0.006       0.002
+ExPng.Color.pixel_bitsize/2                                          2       0.006       0.004
+ExPng.Color.line_bytesize/3                                          1       0.006       0.002
+:zlib.deflateEnd_nif/1                                               1       0.005       0.005
+:zlib.close/1                                                        2       0.005       0.003
+ExPng.Image.Encoding.grayscale?/1                                    1       0.005       0.001
+ExPng.Image.Encoding.black_and_white?/1                              1       0.005       0.001
+ExPng.Chunks.Header.new/2                                            1       0.005       0.003
+ExPng.Chunks.End.to_bytes/1                                          1       0.005       0.001
+:zlib.enqueue_nif/2                                                  2       0.004       0.004
+:erlang.send/3                                                       2       0.004       0.004
+ExPng.Chunks.End.to_bytes/2                                          1       0.004       0.002
+:zlib.inflate_opts/0                                                 1       0.003       0.002
+:zlib.getStash_nif/1                                                 2       0.003       0.003
+:zlib.deflate_opts/1                                                 1       0.003       0.002
+:lists.member/2                                                      3       0.003       0.003
+:erlang.iolist_to_iovec/1                                            2       0.003       0.003
+IO.chardata_to_string/1                                              2       0.003       0.003
+Enum.to_list/1                                                       3       0.003       0.003
+:zlib.inflateEnd/1                                                   1       0.002       0.001
+:zlib.close_nif/1                                                    2       0.002       0.002
+:zlib.arg_level/1                                                    1       0.002       0.002
+:zlib.arg_flush/1                                                    2       0.002       0.002
+:zlib.arg_bitsz/1                                                    2       0.002       0.002
+:io.io_request/2                                                     1       0.002       0.002
+:file.make_binary/1                                                  2       0.002       0.002
+:file.file_name/1                                                    2       0.002       0.002
+:erlang.whereis/1                                                    2       0.002       0.002
+:erlang.list_to_tuple/1                                              2       0.002       0.002
+File.normalize_modes/2                                               1       0.002       0.002
+ExPng.Color.to_bytesize/1                                            2       0.002       0.002
+ExPng.Color.channels_for_color_mode/1                                2       0.002       0.002
+ExPng.Chunks.ImageData.new/2                                         2       0.002       0.002
+anonymous fn/1 in ExPng.Chunks.ImageData.merge/1                     2       0.002       0.002
+ExPng.Chunks.Header.validate_color_mode/1                            2       0.002       0.002
+ExPng.Chunks.Header.validate_bit_depth/1                             2       0.002       0.002
+:zlib.proplist_get_value/3                                           1       0.001       0.001
+:zlib.inflateInit_nif/3                                              1       0.001       0.001
+:zlib.inflateEnd_nif/1                                               1       0.001       0.001
+:zlib.arg_strategy/1                                                 1       0.001       0.001
+:zlib.arg_method/1                                                   1       0.001       0.001
+:zlib.arg_mem/1                                                      1       0.001       0.001
+:zlib.arg_eos_behavior/1                                             1       0.001       0.001
+:fprof."-apply_start_stop/4-after$^1/0-0-"/3                         1       0.001       0.001
+ExPng.Pixel.grayscale?/1                                             1       0.001       0.001
+ExPng.Pixel.black_or_white?/1                                        1       0.001       0.001
+ExPng.Image.Encoding.indexable?/1                                    1       0.001       0.001
+ExPng.Chunks.End.new/2                                               1       0.001       0.001
+:undefined                                                           0       0.000       0.000

--- a/test/ex_png/line_test.exs
+++ b/test/ex_png/line_test.exs
@@ -93,9 +93,7 @@ defmodule ExPng.Image.LineTest do
       with {:ok, canvas} <- ExPng.Image.from_file("test/png_suite/basic/basn0g01.png") do
         check_pixel_dimensions(canvas)
 
-        image = canvas.raw_data
-        line = Enum.at(image.lines, 0)
-        pixels = Line.to_pixels(line, image.header_chunk.bit_depth, image.header_chunk.color_mode)
+        pixels = Enum.at(canvas.pixels, 0)
         assert Enum.at(pixels, 0) == Pixel.white()
         assert Enum.at(pixels, -1) == Pixel.black()
       end
@@ -105,9 +103,7 @@ defmodule ExPng.Image.LineTest do
       with {:ok, canvas} <- ExPng.Image.from_file("test/png_suite/basic/basn0g02.png") do
         check_pixel_dimensions(canvas)
 
-        image = canvas.raw_data
-        line = Enum.at(image.lines, 0)
-        pixels = Line.to_pixels(line, image.header_chunk.bit_depth, image.header_chunk.color_mode)
+        pixels = Enum.at(canvas.pixels, 0)
         assert Enum.at(pixels, 0) == Pixel.black()
         assert Enum.at(pixels, 4) == Pixel.grayscale(85)
         assert Enum.at(pixels, 8) == Pixel.grayscale(170)
@@ -120,16 +116,13 @@ defmodule ExPng.Image.LineTest do
       with {:ok, canvas} <- ExPng.Image.from_file("test/png_suite/basic/basn0g04.png") do
         check_pixel_dimensions(canvas)
 
-        image = canvas.raw_data
-        line = Enum.at(image.lines, 0)
-        pixels = Line.to_pixels(line, image.header_chunk.bit_depth, image.header_chunk.color_mode)
+        pixels = Enum.at(canvas.pixels, 0)
         assert Enum.at(pixels, 0) == Pixel.black()
         assert Enum.at(pixels, 8) == Pixel.grayscale(34)
         assert Enum.at(pixels, 16) == Pixel.grayscale(68)
         assert Enum.at(pixels, 24) == Pixel.grayscale(102)
 
-        line = Enum.at(image.lines, -1)
-        pixels = Line.to_pixels(line, image.header_chunk.bit_depth, image.header_chunk.color_mode)
+        pixels = Enum.at(canvas.pixels, -1)
         assert Enum.at(pixels, 0) == Pixel.grayscale(119)
         assert Enum.at(pixels, 8) == Pixel.grayscale(153)
         assert Enum.at(pixels, 16) == Pixel.grayscale(187)
@@ -212,7 +205,7 @@ defmodule ExPng.Image.LineTest do
 
   defp check_pixel_dimensions(canvas) do
     image = canvas.raw_data
-    assert length(image.lines) == image.header_chunk.height
+    assert length(canvas.pixels) == image.header_chunk.height
 
     for pixels <- canvas.pixels do
       assert length(pixels) == image.header_chunk.width


### PR DESCRIPTION
Various refactors:

* Improve timing of defiltering Paeth-encoded lines by replacing multiple `Enum.at` calls with zipping relevant data into a single list to pass to `Enum.reduce`
* Simplify code for determining which bit depth and color mode to use
* Don't persist `Line` structs on the `RawData`
  * Eventually want to remove these entirely