### PR TITLE
Remove deprecations

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :mix_test_watch,
   tasks: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/lib/ex_png/color.ex
+++ b/lib/ex_png/color.ex
@@ -4,7 +4,6 @@ defmodule ExPng.Color do
   values.
   """
   use ExPng.Constants
-  use Bitwise
 
   @type rgba_value :: 0..255
   @type t :: <<_::32>>

--- a/lib/ex_png/image.ex
+++ b/lib/ex_png/image.ex
@@ -193,7 +193,7 @@ defmodule ExPng.Image do
 end
 
 defimpl Inspect, for: ExPng.Image do
-  use Bitwise
+  import Bitwise
 
   def inspect(%ExPng.Image{pixels: pixels}, _opts) do
     for line <- pixels do

--- a/lib/ex_png/image/adam7.ex
+++ b/lib/ex_png/image/adam7.ex
@@ -1,8 +1,9 @@
 defmodule ExPng.Image.Adam7 do
   @moduledoc false
 
-  use Bitwise
   alias ExPng.{Color, Image, Image.Decoding, Image.Pixelation, RawData}
+
+  import Bitwise
 
   @pass_shifts_and_offsets [
     [3, 0, 3, 0],

--- a/lib/ex_png/image/filtering.ex
+++ b/lib/ex_png/image/filtering.ex
@@ -4,9 +4,9 @@ defmodule ExPng.Image.Filtering do
   image data
   """
 
-  use Bitwise
   use ExPng.Constants
 
+  import Bitwise
   import ExPng.Utilities, only: [reduce_to_binary: 1]
 
   @type filtered_line :: {ExPng.filter(), binary}


### PR DESCRIPTION
- use `import Config` instead of `use Mix.Config`
- use `import Bitwise` instead of `use Bitwise` [Elixir 1.14 hard deprecations](https://github.com/elixir-lang/elixir/blob/main/CHANGELOG.md#4-hard-deprecations)